### PR TITLE
fix version specification on Debian based operating systems

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,27 +8,23 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-6.5
-    driver_config:
-      vm_hostname: false
-      box: centos-6.5
-      network:
-        - ["forwarded_port", {guest: 9042, host: 9042}]
+  - name: ubuntu-12.04
+  - name: ubuntu-14.04
+#  - name: centos-6.5
+  - name: centos-6.6
+
 
 suites:
   - name: default
     run_list: 
       - recipe[dse::cassandra]
     attributes:
-     datacenter: "TTC"
      java:
        oracle:
          accept_oracle_download_terms: true
      cassandra:
-      seeds: "10.0.2.15"
+      seeds: "127.0.0.1"
       memtable_total_space_in_mb: 2048
       memtable_flush_writers: 18
       max_heap_size: "1G"
       heap_newsize: "200M"
-      dse:
-       delegated_snitch: "org.apache.cassandra.locator.GossipingPropertyFileSnitch"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,24 @@ default['cassandra']['hadoop']                 = false
 default['cassandra']['spark']                  = false
 
 default['cassandra']['dse_version']            = '4.0.4-1'
+# The order of this package list is important to be able to install a version other than the latest
+default['cassandra']['packages']               = ['dse-libcassandra',
+                                                  'dse-libhadoop',
+                                                  'dse-libhadoop-native',
+                                                  'dse',
+                                                  'dse-libhive',
+                                                  'dse-hive',
+                                                  'dse-liblog4j',
+                                                  'dse-libmahout',
+                                                  'dse-libpig',
+                                                  'dse-libtomcat',
+                                                  'dse-libsolr',
+                                                  'dse-libspark',
+                                                  'dse-libsqoop',
+                                                  'dse-pig',
+                                                  'dse-demos',
+                                                  'dse-full'
+                                                 ]
 
 default['cassandra']['user']                   = 'cassandra'
 default['cassandra']['group']                  = 'cassandra'

--- a/attributes/opscenter.rb
+++ b/attributes/opscenter.rb
@@ -1,0 +1,1 @@
+default['opscenter']['version'] = '5.0.2'

--- a/recipes/_repo.rb
+++ b/recipes/_repo.rb
@@ -1,0 +1,24 @@
+
+#Set up the datastax repo in yum or apt depending on the OS
+case node['platform']
+when "ubuntu", "debian"
+  include_recipe "apt"
+    apt_repository "datastax" do
+      uri          node['cassandra']['dse']['debian_repo_url']
+      distribution "stable"
+      components   ["main"]
+      key          "http://debian.datastax.com/debian/repo_key"
+      action :add
+    end
+when "redhat", "centos", "fedora", "amazon", "scientific"
+   #We need EPEL
+   include_recipe "yum::default"
+   include_recipe "yum::epel"
+   #Set up datastax repo in yum for rhel
+   yum_repository "datastax" do
+     description "DataStax Enterprise Repo for Apache Cassandra"
+     url node['cassandra']['dse']['rhel_repo_url']
+     repo_name "datastax"
+     action :add
+   end
+end

--- a/recipes/_repo.rb
+++ b/recipes/_repo.rb
@@ -1,24 +1,24 @@
 
-#Set up the datastax repo in yum or apt depending on the OS
+# Set up the datastax repo in yum or apt depending on the OS
 case node['platform']
-when "ubuntu", "debian"
-  include_recipe "apt"
-    apt_repository "datastax" do
-      uri          node['cassandra']['dse']['debian_repo_url']
-      distribution "stable"
-      components   ["main"]
-      key          "http://debian.datastax.com/debian/repo_key"
-      action :add
-    end
-when "redhat", "centos", "fedora", "amazon", "scientific"
-   #We need EPEL
-   include_recipe "yum::default"
-   include_recipe "yum::epel"
-   #Set up datastax repo in yum for rhel
-   yum_repository "datastax" do
-     description "DataStax Enterprise Repo for Apache Cassandra"
-     url node['cassandra']['dse']['rhel_repo_url']
-     repo_name "datastax"
-     action :add
-   end
+when 'ubuntu', 'debian'
+  include_recipe 'apt'
+  apt_repository 'datastax' do
+    uri node['cassandra']['dse']['debian_repo_url']
+    distribution 'stable'
+    components ['main']
+    key 'http://debian.datastax.com/debian/repo_key'
+    action :add
+  end
+when 'redhat', 'centos', 'fedora', 'amazon', 'scientific'
+  # We need EPEL
+  include_recipe 'yum::default'
+  include_recipe 'yum::epel'
+  # Set up datastax repo in yum for rhel
+  yum_repository 'datastax' do
+    description 'DataStax Enterprise Repo for Apache Cassandra'
+    url node['cassandra']['dse']['rhel_repo_url']
+    repo_name 'datastax'
+    action :add
+  end
 end

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -49,7 +49,11 @@ end
 # Check for existing dse version and the version chef wants
 # This will stop DSE before doing an upgrade (if we let chef do the upgrade)
 if File.exist?('/usr/bin/dse')
-  dse_version = Mixlib::ShellOut.new('/usr/bin/dse -v').run_command.stdout.chomp
+  if platform_family?("debian") 
+    dse_version = Mixlib::ShellOut.new('dpkg -l | awk \'$2=="dse" { print $3 }\'').run_command.stdout.chomp.split('-')[0]
+  elsif platform_family?("rhel", "fedora")
+    dse_version = Mixlib::ShellOut.new('/usr/bin/dse -v').run_command.stdout.chomp
+  end
   unless Chef::VersionConstraint.new("= #{node['cassandra']['dse_version'].split('-')[0]}").include?(dse_version)
     execute 'nodetool drain' do
       timeout 30

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -1,6 +1,7 @@
 # This recipe sets up the yum repos, directories, tuning settings, and installs the dse package.
 # Install java
 include_recipe 'java' if node['dse']['manage_java']
+include_recipe 'dse::_repo'
 
 # create the data directories for Cassandra
 node['cassandra']['data_dir'].each do |dir|
@@ -20,30 +21,6 @@ directory node['cassandra']['commit_dir'] do
   mode '755'
   recursive true
   action :create
-end
-
-# Set up the datastax repo in yum or apt depending on the OS
-case node['platform']
-when 'ubuntu', 'debian'
-  include_recipe 'apt'
-  apt_repository 'datastax' do
-    uri node['cassandra']['dse']['debian_repo_url']
-    distribution 'stable'
-    components ['main']
-    key 'http://debian.datastax.com/debian/repo_key'
-    action :add
-  end
-when 'redhat', 'centos', 'fedora', 'amazon', 'scientific'
-  # We need EPEL
-  include_recipe 'yum::default'
-  include_recipe 'yum::epel'
-  # Set up datastax repo in yum for rhel
-  yum_repository 'datastax' do
-    description 'DataStax Enterprise Repo for Apache Cassandra'
-    url node['cassandra']['dse']['rhel_repo_url']
-    repo_name 'datastax'
-    action :add
-  end
 end
 
 # Check for existing dse version and the version chef wants

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -26,9 +26,9 @@ end
 # Check for existing dse version and the version chef wants
 # This will stop DSE before doing an upgrade (if we let chef do the upgrade)
 if File.exist?('/usr/bin/dse')
-  if platform_family?("debian") 
+  if platform_family?('debian')
     dse_version = Mixlib::ShellOut.new('dpkg -l | awk \'$2=="dse" { print $3 }\'').run_command.stdout.chomp.split('-')[0]
-  elsif platform_family?("rhel", "fedora")
+  elsif platform_family?('rhel', 'fedora')
     dse_version = Mixlib::ShellOut.new('/usr/bin/dse -v').run_command.stdout.chomp
   end
   unless Chef::VersionConstraint.new("= #{node['cassandra']['dse_version'].split('-')[0]}").include?(dse_version)

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -65,10 +65,12 @@ end
 case node['platform']
 # make sure not to overwrite any conf files on upgrade
 when 'ubuntu', 'debian'
-  package 'dse-full' do
-    version node['cassandra']['dse_version']
-    action :install
-    options '-o Dpkg::Options::="--force-confold"'
+  node['cassandra']['packages'].each do |install|
+    package install do
+      version node['cassandra']['dse_version']
+      action :install
+      options '-o Dpkg::Options::="--force-confold"'
+    end
   end
 when 'redhat', 'centos', 'fedora', 'scientific', 'amazon'
   package 'dse-full' do

--- a/recipes/opscenter.rb
+++ b/recipes/opscenter.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: dse
+# Recipe:: opscenter
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#Set up the datastax repo in yum or apt depending on the OS
+include_recipe "dse::_repo"
+
+package "opscenter" do
+  version node['opscenter']['version']
+  action :install
+end
+
+service "opscenterd" do
+  action [ :enable, :start ]
+end

--- a/recipes/opscenter.rb
+++ b/recipes/opscenter.rb
@@ -15,14 +15,14 @@
 # limitations under the License.
 #
 
-#Set up the datastax repo in yum or apt depending on the OS
-include_recipe "dse::_repo"
+# Set up the datastax repo in yum or apt depending on the OS
+include_recipe 'dse::_repo'
 
-package "opscenter" do
+package 'opscenter' do
   version node['opscenter']['version']
   action :install
 end
 
-service "opscenterd" do
-  action [ :enable, :start ]
+service 'opscenterd' do
+  action [:enable, :start]
 end

--- a/spec/opscenter_spec.rb
+++ b/spec/opscenter_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+# by default we will test with ubuntu 14.04
+RSpec.configure do |config|
+  config.platform = 'ubuntu'
+  config.version = '14.04'
+end
+
+describe 'dse::opscenter' do
+  let(:chef_run) { ChefSpec::ServerRunner.converge(described_recipe) }
+
+  it 'includes the _repo recipe to setup the local package repositories' do
+    expect(chef_run).to include_recipe('dse::_repo')
+  end
+
+  it 'installs the opscenter server package' do
+    expect(chef_run).to install_package('opscenter')
+  end
+
+  it 'starts the opscenter service deamon' do
+    expect(chef_run).to start_service('opscenterd')
+  end
+end


### PR DESCRIPTION
There is an issue that installing any version of dse-full on Debian based systems installs the latest versions of the packages from the repo rather than the version specified in the default['cassandra']['dse_version'] attribute.

This patch will first install all dependencies in order by version number prior to installing the dse-full package.

There is also some genericification of the .kitchen.yml file.