### PR TITLE
Add hosts and local_interface options to address.yaml

### DIFF
--- a/templates/default/address.yaml.erb
+++ b/templates/default/address.yaml.erb
@@ -1,1 +1,7 @@
 stomp_interface: "<%= node['datastax-agent']['opscenter-ip'] %>"
+<% if node["datastax-agent"]["hosts"] %>
+hosts: <%= node["datastax-agent"]["hosts"] %>
+<% end %>
+<% if node["datastax-agent"]["local_interface"] %>
+local_interface: "<%= node["datastax-agent"]["local_interface"] %>"
+<% end %>


### PR DESCRIPTION
Add a couple of extra optional items to datastax-agent address.yaml, including `hosts` which is new in 5.1 http://www.datastax.com/documentation/upgrade/doc/upgrade/opscenter/opscUpgradeTo5_1.html