### PR TITLE
Add orbited_longpoll option to opscenterd.conf

### DIFF
--- a/attributes/opscenter.rb
+++ b/attributes/opscenter.rb
@@ -10,3 +10,8 @@ default['opscenter']['ssl_port'] = nil
 default['opscenter']['auth_enabled'] = 'False'
 
 default['opscenter']['stat_reporter_interval'] = nil
+
+# Set use_longpoll to true if you experience connectivity issues between the
+# browser and opscenterd leading to 0 nodes showing
+# http://www.datastax.com/documentation/opscenter/5.1/opsc/troubleshooting/opscTroubleshootingZeroNodes.html
+default['opscenter']['use_longpoll'] = false

--- a/templates/default/opscenterd.conf.erb
+++ b/templates/default/opscenterd.conf.erb
@@ -35,3 +35,9 @@ enabled = <%= node['opscenter']['auth_enabled'] %>
 # reporting, set to 0
 # interval = 86400 # 24 hours
 <%= "interval = #{node['opscenter']['stat_reporter_interval']}" if node['opscenter']['stat_reporter_interval'] -%>
+
+
+<% if node["opscenter"]["use_longpoll"] %>
+[labs]
+orbited_longpoll = true
+<% end %>


### PR DESCRIPTION
I was bitten by http://www.datastax.com/documentation/opscenter/5.1/opsc/troubleshooting/opscTroubleshootingZeroNodes.html, and had to add `orbited_longpoll` to opscenterd.conf to fix it.