### PR TITLE
dc_suffix is applied to Ec2 snitches

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -61,15 +61,16 @@ template "#{node['cassandra']['dse']['conf_dir']}/cassandra/cassandra-env.sh" do
 end
 
 # check what kind of snitch is set, since it requires different templates.
-case node['cassandra']['dse']['delegated_snitch']
+snitch = (node['cassandra']['dse']['delegated_snitch'] || node['cassandra']['dse']['snitch']).split('.').last
+case snitch
 # GossipingPropertyFile
-when 'org.apache.cassandra.locator.GossipingPropertyFileSnitch'
+when 'GossipingPropertyFileSnitch', 'Ec2Snitch', 'Ec2MultiRegionSnitch'
   template "#{node['cassandra']['dse']['conf_dir']}/cassandra/cassandra-rackdc.properties" do
     source 'cassandra-rackdc.properties.erb'
     owner node['cassandra']['user']
     group node['cassandra']['group']
   end
-when 'org.apache.cassandra.locator.PropertyFileSnitch'
+when 'PropertyFileSnitch'
   # This requires a variable of cluster to be created.
   # This has been mostly deprecated in the use of this cookbook, but should still work.
   # Requires a chef search or some type of variable so every node knows every other node's datacenter and IP

--- a/templates/default/cassandra-rackdc.properties.erb
+++ b/templates/default/cassandra-rackdc.properties.erb
@@ -27,7 +27,7 @@ rack=RAC1
 
 # Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch
 # to append a string to the EC2 region name.
-<% if node[:cassandra][:dse][:snitch].split('.').last.start_with?('Ec2') %>
+<% if node['cassandra']['dse']['snitch'].split('.').last.start_with?('Ec2') %>
 dc_suffix=_<%= node['datacenter'] %>
 <% else %>
 #dc_suffix=

--- a/templates/default/cassandra-rackdc.properties.erb
+++ b/templates/default/cassandra-rackdc.properties.erb
@@ -27,4 +27,8 @@ rack=RAC1
 
 # Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch
 # to append a string to the EC2 region name.
+<% if node[:cassandra][:dse][:snitch].split('.').last.start_with?('Ec2') %>
+dc_suffix=_<%= node['datacenter'] %>
+<% else %>
 #dc_suffix=
+<% end %>


### PR DESCRIPTION
If using AWS, data centers are configured based on the suffix.

This PR applies the `datacenter` attribute to the `dc_suffix` property if using any Ec2 snitch.