### PR TITLE
updated berkshelf version to avoid the Faraday error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'berkshelf', '~> 3.2.1'
+gem 'berkshelf', '~> 4.0.1'
 
 group :test do
   gem 'foodcritic', '~> 4.0.0'


### PR DESCRIPTION
I've experienced the same error in my local machine and both of them work

1. Updating ChefDK to 0.9.0 and running `chef exec berks install`
2. Updating Berkshelf gem to 4.0.1 and running `berks install`