### PR TITLE
install datastax-agent beforehead otherwise set version may not be fulfilled

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'daniel.c.parker@target.com'
 license 'Apache 2.0'
 description 'Installs/Configures Datastax Enterprise.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.0.22'
+version '3.0.23'
 
 %w(redhat centos).each do |name|
   supports name, '>= 6.4'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -28,6 +28,13 @@ case node['platform']
 # make sure not to overwrite any conf files on upgrade
 when 'ubuntu', 'debian'
   node['cassandra']['packages'].each do |install|
+    # We need to install datastax-agent upfront because dse package has it as an
+    # open dependency and therefore the specified datastax-agent version may not
+    # be fulfilled.
+    package 'datastax-agent' do
+      version node['datastax-agent']['version']
+      action :install
+    end
     package install do
       version node['cassandra']['dse_version']
       action :install


### PR DESCRIPTION
DataStax Agent package is contained as an open dependency of DSE package, that was installed before, installing latest datastax-agent version. If you have specified an earlier version for that package, even if its a patch one, it would fail. Installing it upfront fixes this.