### PR TITLE
Install dse-libspark when dse version is 4.x also.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,7 @@ default['cassandra']['packages']               = ['dse-libcassandra',
                                                   'dse-demos'
                                                  ]
 
-unless node['cassandra']['dse_version'].match(/4\.0.*/)
+unless node['cassandra']['dse_version'].match(/4\..*/)
   default['cassandra']['packages'] << 'dse-libspark'
 end
 


### PR DESCRIPTION
Currently dse-libspark is only installed for 4.0.x. This breaks things
if we install old version of dse.