### PR TITLE
Removed 'enabled' from 'node_health_options' section of 4.8.* dse.yaml.

### DIFF
--- a/templates/default/dse_yaml/dse_4.8.0-1.yaml.erb
+++ b/templates/default/dse_yaml/dse_4.8.0-1.yaml.erb
@@ -286,7 +286,6 @@ solr_latency_snapshot_options:
 
 # NodeHealth options
 node_health_options:
-    enabled: <%= node['cassandra']['dse']['node_health_options']['enabled'] %>
     refresh_rate_ms: <%= node['cassandra']['dse']['node_health_options']['refresh_rate_ms'] %>
 
 # The directory where system keys are kept


### PR DESCRIPTION
Removed 'enabled' from 'node_health_options' section of 4.8.* dse.yaml.  This is to address Issue #45 discovered by @larsp.