### PR TITLE
Add Client SSL, Broadcast RPC Address, Ensure group & user exists, Fixed agent SSL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,9 +326,11 @@ These are generic java settings. Datastax recommends oracle java, so override op
 This portion is under construction. SSL does not currently 100% work.
  * `node["cassandra"]["dse"]["cassandra_ssl_dir"]` (default: `/etc/cassandra`): the directory to use for pem files
  * `node["cassandra"]["dse"]["password_file"]` (default: `cassandra_pass.txt`): the file to store the keystore pass in
- * `node["cassandra"]["dse"]["internode_encyption"]` (default: `none`): the encyption to use (all, dc, rack)
+ * `node["cassandra"]["dse"]["internode_encryption"]` (default: `none`): the encyption to use (all, dc, rack)
  * `node["cassandra"]["dse"]["keystore"]` (default: `#{node["cassandra"]["dse"]["cassandra_ssl_dir"]}/#{node["hostname"]}.keystore`): keystore name
  * `node["cassandra"]["dse"]["truststore"]` (default: `#{node["cassandra"]["dse"]["cassandra_ssl_dir"]}/#{node["hostname"]}.truststore`): truststore name
+ * `node["cassandra"]["dse"]["client_encryption_enabled"]` (default: `false`): enable client-to-node encryption
+ * `node["cassandra"]["dse"]["import_public_keys"]` (default: `true`): allow attempt to import public keys during Chef run
 
 ### datastax-agent.rb
 These attributes are used to conigure the datastax-agent. This is used with Datastax Opscenter.
@@ -337,6 +339,7 @@ These attributes are used to conigure the datastax-agent. This is used with Data
 * `node["datastax-agent"]["version"]` (default: `4.1.1-1`): the version of the datastax agent to install
 * `node["datastax-agent"]["conf_dir"]` (default: `/var/lib/datastax-agent/conf`): where the datastax-agent conf file is
 * `node["datastax-agent"]["opscenter_ip"]` (default: `192.168.32.3`): the Opscenter IP to connect to
+* `node["datastax-agent"]["use_ssl"]` (default: `nil`): enable the use of SSL for datastax agent communication with opscenter
 
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This cookbook will install DSE Cassandra by default. Other attributes you can se
 #### cassandra.yaml settings
  * `node["cassandra"]["listen_address"]` (default: `node['ipaddress']`): the ipaddress to use for listen address
  * `node["cassandra"]["rpc_address"]` (default: `node['ipaddress']`): the ipaddress to use for rpc address
+ * `node["cassandra"]["broadcast_rpc_address"]` (default: `nill`): the rpc address to broadcast to drivers & nodes
  * `node["cassandra"]["broadcast_address"]` (default: `nil`): the ipaddress to use for broadcast address
  * `node["cassandra"]["seeds"]` (default: `node['ipaddress']`): the ipaddress to use for the seed list
  * `node["cassandra"]["concurrent_reads"]` (default: `32`): concurrent reads setting

--- a/attributes/datastax_agent.rb
+++ b/attributes/datastax_agent.rb
@@ -3,3 +3,4 @@ default['datastax-agent']['enabled'] = false
 default['datastax-agent']['version'] = '4.1.1-1'
 default['datastax-agent']['conf_dir'] = '/var/lib/datastax-agent/conf'
 default['datastax-agent']['opscenter-ip'] = nil
+default['datastax-agent']['use_ssl'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default['cassandra']['commit_dir']             = '/var/lib/cassandra/commitlog'
 
 default['cassandra']['listen_address']         = node['ipaddress']
 default['cassandra']['rpc_address']            = node['ipaddress']
+default['cassandra']['broadcast_rpc_address']  = nil
 default['cassandra']['broadcast_address']      = nil
 default['cassandra']['seeds']                  = node['ipaddress']
 default['cassandra']['concurrent_reads']       = 32

--- a/attributes/ssl.rb
+++ b/attributes/ssl.rb
@@ -4,3 +4,5 @@ default['cassandra']['dse']['password_file']         = 'cassandra_pass.txt'
 default['cassandra']['dse']['internode_encryption']  = 'none'
 default['cassandra']['dse']['keystore']              = "#{node['cassandra']['dse']['cassandra_ssl_dir']}/#{node['hostname']}.keystore"
 default['cassandra']['dse']['truststore']            = "#{node['cassandra']['dse']['cassandra_ssl_dir']}/#{node['hostname']}.truststore"
+default['cassandra']['dse']['client_encryption_enabled'] = false
+default['cassandra']['dse']['import_public_keys'] = true

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -48,6 +48,20 @@ when 'redhat', 'centos', 'fedora', 'scientific', 'amazon'
   end
 end
 
+# create group
+group node['cassandra']['group'] do
+  system true
+  action :create
+end
+
+# create user
+user node['cassandra']['user'] do
+  comment 'DSE Cassandra User'
+  gid node['cassandra']['group']
+  system true
+  action :create
+end
+
 # create the data directories for Cassandra
 node['cassandra']['data_dir'].each do |dir|
   directory dir do
@@ -59,13 +73,16 @@ node['cassandra']['data_dir'].each do |dir|
   end
 end
 
-# Make sure the commit directory exists (in case we changed it from default)
-directory node['cassandra']['commit_dir'] do
-  owner node['cassandra']['user']
-  group node['cassandra']['group']
-  mode '755'
-  recursive true
-  action :create
+# Make sure the commit & saved_caches directory exists (in case we changed it from default)
+[node['cassandra']['commit_dir'],
+ File.join(node['cassandra']['root_dir'], 'saved_caches')].each do |dir|
+  directory dir do
+    owner node['cassandra']['user']
+    group node['cassandra']['group']
+    mode '755'
+    recursive true
+    action :create
+  end
 end
 
 # do you want the datastax-agent for opscenter?

--- a/recipes/opscenter.rb
+++ b/recipes/opscenter.rb
@@ -37,4 +37,5 @@ end
 service 'opscenterd' do
   action [:enable, :start]
   pattern 'start_opscenter.py'
+  subscribes :restart, 'template[/etc/opscenter/opscenterd.conf]'
 end

--- a/recipes/ssl.rb
+++ b/recipes/ssl.rb
@@ -63,5 +63,6 @@ bash 'import public keys' do
   not_if do
     File.exist?("#{node['cassandra']['dse']['cassandra_ssl_dir']}/#{node['hostname']}.imported")
   end
+  only_if { node['cassandra']['dse']['import_public_keys'] }
 end
 # end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -9,6 +9,19 @@ end
 describe 'dse with default settings' do
   cached(:chef_run) { ChefSpec::ServerRunner.converge('dse::default') }
 
+  it 'create group' do
+    expect(chef_run).to create_group('cassandra').with(
+      system: true
+    )
+  end
+
+  it 'create user' do
+    expect(chef_run).to create_user('cassandra').with(
+      system: true,
+      gid: 'cassandra'
+    )
+  end
+
   it 'creates the cassandra data directory /data/cassandra' do
     expect(chef_run).to create_directory('/data/cassandra').with(
       user: 'cassandra',
@@ -20,6 +33,15 @@ describe 'dse with default settings' do
 
   it 'creates the cassandra commit log directory /var/lib/cassandra/commitlog' do
     expect(chef_run).to create_directory('/var/lib/cassandra/commitlog').with(
+      user: 'cassandra',
+      group: 'cassandra',
+      mode: '755',
+      recursive: true
+    )
+  end
+
+  it 'creates the cassandra saved caches directory /var/lib/cassandra/saved_caches' do
+    expect(chef_run).to create_directory('/var/lib/cassandra/saved_caches').with(
       user: 'cassandra',
       group: 'cassandra',
       mode: '755',

--- a/spec/opscenter_spec.rb
+++ b/spec/opscenter_spec.rb
@@ -24,6 +24,8 @@ describe 'dse::opscenter' do
       owner: 'root',
       group: 'root'
     )
+    template = chef_run.template('/etc/opscenter/opscenterd.conf')
+    expect(template).to notify('service[opscenterd]').to(:restart)
   end
 
   it 'renders the opscenterd.conf file with content from ./spec/rendered_templates/opscenterd.conf' do

--- a/templates/default/address.yaml.erb
+++ b/templates/default/address.yaml.erb
@@ -5,3 +5,5 @@ hosts: <%= node["datastax-agent"]["hosts"] %>
 <% if node["datastax-agent"]["local_interface"] %>
 local_interface: "<%= node["datastax-agent"]["local_interface"] %>"
 <% end %>
+
+use_ssl: <%= !node["datastax-agent"]["use_ssl"].nil? && node["datastax-agent"]["use_ssl"]%>

--- a/templates/default/cassandra_yaml/cassandra_4.7.2-1.yaml.erb
+++ b/templates/default/cassandra_yaml/cassandra_4.7.2-1.yaml.erb
@@ -479,7 +479,7 @@ rpc_port: 9160
 # be set to 0.0.0.0. If left blank, this will be set to the value of
 # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
 # be set.
-# broadcast_rpc_address: 1.2.3.4
+<%= !node['cassandra']['broadcast_rpc_address'].nil? ? "broadcast_rpc_address: #{node['cassandra']['broadcast_rpc_address']}" : "# broadcast_rpc_address: 1.2.3.4"%>
 
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true
@@ -813,9 +813,9 @@ server_encryption_options:
 
 # enable or disable client/server encryption.
 client_encryption_options:
-    enabled: false
-    keystore: resources/dse/conf/.keystore
-    keystore_password: cassandra
+    enabled: <%= node["cassandra"]["dse"]["client_encryption_enabled"] %>
+    keystore: <%= node["cassandra"]["dse"]["keystore"] %>
+    keystore_password: <%= @ssl_password.call %>
     # require_client_auth: false
     # Set trustore and truststore_password if require_client_auth is true
     # truststore: resources/dse/conf/.truststore

--- a/templates/default/cassandra_yaml/cassandra_4.8.0-1.yaml.erb
+++ b/templates/default/cassandra_yaml/cassandra_4.8.0-1.yaml.erb
@@ -487,7 +487,7 @@ rpc_port: 9160
 # be set to 0.0.0.0. If left blank, this will be set to the value of
 # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
 # be set.
-# broadcast_rpc_address: 1.2.3.4
+<%= !node['cassandra']['broadcast_rpc_address'].nil? ? "broadcast_rpc_address: #{node['cassandra']['broadcast_rpc_address']}" : "# broadcast_rpc_address: 1.2.3.4"%>
 
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true

--- a/templates/default/cassandra_yaml/cassandra_4.8.0-1.yaml.erb
+++ b/templates/default/cassandra_yaml/cassandra_4.8.0-1.yaml.erb
@@ -825,9 +825,9 @@ server_encryption_options:
 
 # enable or disable client/server encryption.
 client_encryption_options:
-    enabled: false
-    keystore: resources/dse/conf/.keystore
-    keystore_password: cassandra
+    enabled: <%= node["cassandra"]["dse"]["client_encryption_enabled"] %>
+    keystore: <%= node["cassandra"]["dse"]["keystore"] %>
+    keystore_password: <%= @ssl_password.call %>
     # require_client_auth: false
     # Set trustore and truststore_password if require_client_auth is true
     # truststore: resources/dse/conf/.truststore

--- a/templates/default/opscenterd.conf.erb
+++ b/templates/default/opscenterd.conf.erb
@@ -8,11 +8,11 @@ interface = <%= node['opscenter']['http_interface'] %>
 # that you wish to use for your OpsCenter install, as well as the port you would like
 # to serve ssl traffic from.
 #ssl_keyfile = /var/lib/opscenter/ssl/opscenter.key
-<%= "ssl_keyfile = #{node['opscenter']['ssl_keyfile']}" if node['opscenter']['ssl_keyfile'] -%>
+<%= "ssl_keyfile = #{node['opscenter']['ssl_keyfile']}" + "\n" if node['opscenter']['ssl_keyfile'] -%>
 #ssl_certfile = /var/lib/opscenter/ssl/opscenter.pem
-<%= "ssl_certifile = #{node['opscenter']['ssl_certfile']}" if node['opscenter']['ssl_certfile'] -%>
+<%= "ssl_certfile = #{node['opscenter']['ssl_certfile']}" + "\n" if node['opscenter']['ssl_certfile'] -%>
 #ssl_port = 8443
-<%= "ssl_port = #{node['opscenter']['ssl_port']}" if node['opscenter']['ssl_port'] -%>
+<%= "ssl_port = #{node['opscenter']['ssl_port']}" + "\n" if node['opscenter']['ssl_port'] -%>
 
 [logging]
 # level may be TRACE, DEBUG, INFO, WARN, or ERROR
@@ -68,3 +68,8 @@ enabled = <%= node['opscenter']['auth_enabled'] %>
 [labs]
 orbited_longpoll = true
 <% end -%>
+
++<% if !node["datastax-agent"]["use_ssl"].nil? && node["datastax-agent"]["use_ssl"] -%>
++[agents]
++use_ssl = true
++<% end -%>


### PR DESCRIPTION
* Added some attributes to the "client_encryption_options" of Cassandra YAML.
* Added ability to specify broadcast_rpc_address
* Ensured Group & User exists before attempting to create directories
* Fixed issues with datastax-agent SSL configuration.
* Added restart of opscenterd when changes to it's conf file occur.
* Added ability to "bypass" the "import_public_keys" section of the SSL recipe (our shop uses different process [& cookbook] to pull this together)