### PR TITLE
Enable management of permissions validity and cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ This cookbook will install DSE Cassandra by default. Other attributes you can se
  * `node["cassandra"]["thrift_framed_transport_size_in_mb"]` (default: `15`): the max size of a thrift frame
  * `node["cassandra"]["thrift_max_message_length_in_mb"]` (default: `nil`): the max message length of a thrift call
  * `node["cassandra"]["concurrent_compactors"]` (default: `nil`): the number of concurrent compactors to allow
+ * `node["cassanrda"]["permissions_validity_in_ms"]` (default: `2000`): validity period for permissions cache (disabled for AllowAllAuthorizer)
+ * `node["cassandra"]["permissions_update_interval_in_ms"]` (default: `nil`): refresh interval for permissions cache
 
 #### Role based seed selection
  * `node["cassandra"]["role_based_seeds"]` (default: `false`): set to true to assign seeds based on members of dse-seed role

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,7 @@ default['cassandra']['request_timeout_in_ms'] = 10_000
 default['cassandra']['thrift_framed_transport_size_in_mb'] = '15'
 default['cassandra']['thrift_max_message_length_in_mb'] = nil
 default['cassandra']['concurrent_compactors']   = nil
+default['cassandra']['permissions_validity_in_ms']  = 2000
 
 # Role based search to assign seed nodes.
 default['cassandra']['role_based_seeds'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'daniel.c.parker@target.com'
 license 'Apache 2.0'
 description 'Installs/Configures Datastax Enterprise.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.0.31'
+version '3.0.32'
 
 %w(redhat centos).each do |name|
   supports name, '>= 6.4'

--- a/templates/default/cassandra_yaml/cassandra_4.8.6-1.yaml.erb
+++ b/templates/default/cassandra_yaml/cassandra_4.8.6-1.yaml.erb
@@ -99,7 +99,7 @@ authorizer: AllowAllAuthorizer
 # expensive operation depending on the authorizer, CassandraAuthorizer is
 # one example). Defaults to 2000, set to 0 to disable.
 # Will be disabled automatically for AllowAllAuthorizer.
-permissions_validity_in_ms: 2000
+permissions_validity_in_ms: <%= node[:cassandra][:permissions_validity_in_ms] %> #2000
 
 # Refresh interval for permissions cache (if enabled).
 # After this interval, cache entries become eligible for refresh. Upon next
@@ -107,7 +107,11 @@ permissions_validity_in_ms: 2000
 # completes. If permissions_validity_in_ms is non-zero, then this must be
 # also.
 # Defaults to the same value as permissions_validity_in_ms.
+<% if node[:cassandra][:permissions_update_interval_in_ms] %>
+permissions_update_interval_in_ms: <%= node[:cassandra][:permissions_update_interval_in_ms] %>
+<% else %>
 # permissions_update_interval_in_ms: 1000
+<% end %>
 
 # The partitioner is responsible for distributing groups of rows (by
 # partition key) across nodes in the cluster.  You should leave this


### PR DESCRIPTION
In our use case, we need to be able to configure the `permissions_validity_in_ms` option, as well as `permissions_update_interval_in_ms`.

By default they are the same value, causing long delays every few seconds as the user is re-authorized.