### PR TITLE
Templates and configuration for release 5.0.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,7 @@ default['cassandra']['vnodes']                 = true
 default['cassandra']['initial_token']          = ''
 default['cassandra']['num_tokens']             = '256'
 default['cassandra']['solr']		       = false
+default['cassandra']['graph']                  = false
 default['cassandra']['hadoop']                 = false
 default['cassandra']['spark']                  = false
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,7 +43,9 @@ default['cassandra']['root_dir']               = '/var/lib/cassandra/'
 default['cassandra']['commit_dir']             = '/var/lib/cassandra/commitlog'
 
 default['cassandra']['listen_address']         = node['ipaddress']
+default['cassandra']['listen_interface']       = nil
 default['cassandra']['rpc_address']            = node['ipaddress']
+default['cassandra']['rpc_interface']          = nil
 default['cassandra']['broadcast_rpc_address']  = nil
 default['cassandra']['broadcast_address']      = nil
 default['cassandra']['seeds']                  = node['ipaddress']

--- a/attributes/dse.rb
+++ b/attributes/dse.rb
@@ -42,6 +42,7 @@ default['cassandra']['dse']['ldap_options']['connection_pool']['max_idle'] = nil
 
 default['cassandra']['dse']['cql_slow_log_options']['enabled'] = true
 default['cassandra']['dse']['cql_slow_log_options']['threshold_ms'] = 2_000
+default['cassandra']['dse']['cql_slow_log_options']['minimum_samples'] = 100
 default['cassandra']['dse']['cql_slow_log_options']['ttl_seconds'] = 259_200
 default['cassandra']['dse']['cql_slow_log_options']['async_writers'] = 1
 default['cassandra']['dse']['cql_system_info_options']['enabled'] = false

--- a/attributes/graph.rb
+++ b/attributes/graph.rb
@@ -1,0 +1,1 @@
+default['graph']['port'] = '8182'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -60,11 +60,28 @@ template "#{node['cassandra']['dse']['conf_dir']}/cassandra/cassandra.yaml" do
   group node['cassandra']['group']
 end
 
-# set up the cassandra-env.sh template (this contains java heap settings)
-template "#{node['cassandra']['dse']['conf_dir']}/cassandra/cassandra-env.sh" do
-  source 'cassandra-env.sh.erb'
-  owner node['cassandra']['user']
-  group node['cassandra']['group']
+# check version of dse, jvm.options was introduced in 5.0.0-1
+if node['cassandra']['dse_version'] >= '5.0.0-1'
+  # set up the cassandra-env.sh template (this contains default java heap settings)
+  template "#{node['cassandra']['dse']['conf_dir']}/cassandra/cassandra-env.sh" do
+    source "cassandra-env_#{node['cassandra']['dse_version']}.sh.erb"
+    owner node['cassandra']['user']
+    group node['cassandra']['group']
+  end
+
+  # set up JVM options (this overrides automatically derived values from cassandra-env)
+  template "#{node['cassandra']['dse']['conf_dir']}/cassandra/jvm.options" do
+    source 'cassandra-jvm.options.erb'
+    owner node['cassandra']['user']
+    group node['cassandra']['group']
+  end
+else
+  # set up the cassandra-env.sh template (this contains java heap settings)
+  template "#{node['cassandra']['dse']['conf_dir']}/cassandra/cassandra-env.sh" do
+    source 'cassandra-env.sh.erb'
+    owner node['cassandra']['user']
+    group node['cassandra']['group']
+  end
 end
 
 # check what kind of snitch is set, since it requires different templates.

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -155,6 +155,22 @@ describe 'dse with default settings' do
   end
 end
 
+describe 'dse with node[\'cassandra\'][\'dse_version\'] >= 5.0.0-1' do
+  cached(:chef_run) do
+    ChefSpec::ServerRunner.new do |node|
+      node.set['cassandra']['dse_version'] = '5.0.0-1'
+    end.converge('dse')
+  end
+
+  it 'creates the template /etc/dse/cassandra/jvm.options' do
+    expect(chef_run).to create_template('/etc/dse/cassandra/jvm.options').with(
+      source: 'cassandra-jvm.options.erb',
+      owner: 'cassandra',
+      group: 'cassandra'
+    )
+  end
+end
+
 describe 'dse with node[\'datastax-agent\'][\'enabled\'] true' do
   cached(:chef_run) do
     ChefSpec::ServerRunner.new do |node|

--- a/templates/default/cassandra-env_5.0.0-1.sh.erb
+++ b/templates/default/cassandra-env_5.0.0-1.sh.erb
@@ -1,0 +1,334 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+calculate_heap_sizes()
+{
+    case "`uname`" in
+        Linux)
+            system_memory_in_mb=`free -m | awk '/:/ {print $2;exit}'`
+            system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
+        ;;
+        FreeBSD)
+            system_memory_in_bytes=`sysctl hw.physmem | awk '{print $2}'`
+            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
+            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
+        ;;
+        SunOS)
+            system_memory_in_mb=`prtconf | awk '/Memory size:/ {print $3}'`
+            system_cpu_cores=`psrinfo | wc -l`
+        ;;
+        Darwin)
+            system_memory_in_bytes=`sysctl hw.memsize | awk '{print $2}'`
+            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
+            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
+        ;;
+        *)
+            # assume reasonable defaults for e.g. a modern desktop or
+            # cheap server
+            system_memory_in_mb="2048"
+            system_cpu_cores="2"
+        ;;
+    esac
+
+    # some systems like the raspberry pi don't report cores, use at least 1
+    if [ "$system_cpu_cores" -lt "1" ]
+    then
+        system_cpu_cores="1"
+    fi
+
+    # set max heap size based on the following
+    # max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+    # calculate 1/2 ram and cap to 1024MB
+    # calculate 1/4 ram and cap to 8192MB
+    # pick the max
+    half_system_memory_in_mb=`expr $system_memory_in_mb / 2`
+    quarter_system_memory_in_mb=`expr $half_system_memory_in_mb / 2`
+    if [ "$half_system_memory_in_mb" -gt "1024" ]
+    then
+        half_system_memory_in_mb="1024"
+    fi
+    if [ "$quarter_system_memory_in_mb" -gt "8192" ]
+    then
+        quarter_system_memory_in_mb="8192"
+    fi
+    if [ "$half_system_memory_in_mb" -gt "$quarter_system_memory_in_mb" ]
+    then
+        max_heap_size_in_mb="$half_system_memory_in_mb"
+    else
+        max_heap_size_in_mb="$quarter_system_memory_in_mb"
+    fi
+    MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
+
+    # Young gen: min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
+    max_sensible_yg_per_core_in_mb="100"
+    max_sensible_yg_in_mb=`expr $max_sensible_yg_per_core_in_mb "*" $system_cpu_cores`
+
+    desired_yg_in_mb=`expr $max_heap_size_in_mb / 4`
+
+    if [ "$desired_yg_in_mb" -gt "$max_sensible_yg_in_mb" ]
+    then
+        HEAP_NEWSIZE="${max_sensible_yg_in_mb}M"
+    else
+        HEAP_NEWSIZE="${desired_yg_in_mb}M"
+    fi
+}
+
+# Determine the sort of JVM we'll be running on.
+java_ver_output=`"${JAVA:-java}" -version 2>&1`
+jvmver=`echo "$java_ver_output" | grep '[openjdk|java] version' | awk -F'"' 'NR==1 {print $2}'`
+JVM_VERSION=${jvmver%_*}
+JVM_PATCH_VERSION=${jvmver#*_}
+
+if [ "$JVM_VERSION" \< "1.8" ] ; then
+    echo "DSE 5.0 requires Java 8u40 or later."
+    exit 1;
+fi
+
+if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" -lt 40 ] ; then
+    echo "DSE 5.0 requires Java 8u40 or later."
+    exit 1;
+fi
+
+jvm=`echo "$java_ver_output" | grep -A 1 'java version' | awk 'NR==2 {print $1}'`
+case "$jvm" in
+    OpenJDK)
+        JVM_VENDOR=OpenJDK
+        # this will be "64-Bit" or "32-Bit"
+        JVM_ARCH=`echo "$java_ver_output" | awk 'NR==3 {print $2}'`
+        ;;
+    "Java(TM)")
+        JVM_VENDOR=Oracle
+        # this will be "64-Bit" or "32-Bit"
+        JVM_ARCH=`echo "$java_ver_output" | awk 'NR==3 {print $3}'`
+        ;;
+    *)
+        # Help fill in other JVM values
+        JVM_VENDOR=other
+        JVM_ARCH=unknown
+        ;;
+esac
+
+# Here we create the arguments that will get passed to the jvm when
+# starting cassandra.
+
+# Read user-defined JVM options from jvm.options file
+JVM_OPTS_FILE=$CASSANDRA_CONF/jvm.options
+for opt in `grep "^-" $JVM_OPTS_FILE`
+do
+  JVM_OPTS="$JVM_OPTS $opt"
+done
+
+# Check what parameters were defined on jvm.options file to avoid conflicts
+echo $JVM_OPTS | grep -q Xmn
+DEFINED_XMN=$?
+echo $JVM_OPTS | grep -q Xmx
+DEFINED_XMX=$?
+echo $JVM_OPTS | grep -q Xms
+DEFINED_XMS=$?
+echo $JVM_OPTS | grep -q UseConcMarkSweepGC
+USING_CMS=$?
+echo $JVM_OPTS | grep -q UseG1GC
+USING_G1=$?
+
+# Override these to set the amount of memory to allocate to the JVM at
+# start-up. For production use you may wish to adjust this for your
+# environment. MAX_HEAP_SIZE is the total amount of memory dedicated
+# to the Java heap. HEAP_NEWSIZE refers to the size of the young
+# generation. Both MAX_HEAP_SIZE and HEAP_NEWSIZE should be either set
+# or not (if you set one, set the other).
+#
+# The main trade-off for the young generation is that the larger it
+# is, the longer GC pause times will be. The shorter it is, the more
+# expensive GC will be (usually).
+#
+# The example HEAP_NEWSIZE assumes a modern 8-core+ machine for decent pause
+# times. If in doubt, and if you do not particularly want to tweak, go with
+# 100 MB per physical CPU core.
+
+<% if node['cassandra']['solr'] %>
+MAX_HEAP_SIZE="<%= node['solr']['max_heap_size'] %>"
+HEAP_NEWSIZE="<%= node['solr']['heap_newsize'] %>"
+<% elsif node['cassandra']['hadoop'] %>
+MAX_HEAP_SIZE="<%= node['hadoop']['max_heap_size'] %>"
+HEAP_NEWSIZE="<%= node['hadoop']['heap_newsize'] %>"
+<% else %>
+MAX_HEAP_SIZE="<%= node['cassandra']['max_heap_size'] %>"
+HEAP_NEWSIZE="<%= node['cassandra']['heap_newsize'] %>"
+<% end %>
+
+# Set this to control the amount of arenas per-thread in glibc
+#export MALLOC_ARENA_MAX=4
+
+# only calculate the size if it's not set manually
+if [ "x$MAX_HEAP_SIZE" = "x" ] && [ "x$HEAP_NEWSIZE" = "x" -o $USING_G1 -eq 0 ]; then
+    calculate_heap_sizes
+elif [ "x$MAX_HEAP_SIZE" = "x" ] ||  [ "x$HEAP_NEWSIZE" = "x" -a $USING_G1 -ne 0 ]; then
+    echo "please set or unset MAX_HEAP_SIZE and HEAP_NEWSIZE in pairs when using CMS GC (see cassandra-env.sh)"
+    exit 1
+fi
+
+if [ "x$MALLOC_ARENA_MAX" = "x" ] ; then
+    export MALLOC_ARENA_MAX=4
+fi
+
+# We only set -Xms and -Xmx if they were not defined on jvm.options file
+# If defined, both Xmx and Xms should be defined together.
+if [ $DEFINED_XMX -ne 0 ] && [ $DEFINED_XMS -ne 0 ]; then
+     JVM_OPTS="$JVM_OPTS -Xms${MAX_HEAP_SIZE}"
+     JVM_OPTS="$JVM_OPTS -Xmx${MAX_HEAP_SIZE}"
+elif [ $DEFINED_XMX -ne 0 ] || [ $DEFINED_XMS -ne 0 ]; then
+     echo "Please set or unset -Xmx and -Xms flags in pairs on jvm.options file."
+     exit 1
+fi
+
+# We only set -Xmn flag if it was not defined in jvm.options file
+# and if the CMS GC is being used
+# If defined, both Xmn and Xmx should be defined together.
+if [ $DEFINED_XMN -eq 0 ] && [ $DEFINED_XMX -ne 0 ]; then
+    echo "Please set or unset -Xmx and -Xmn flags in pairs on jvm.options file."
+    exit 1
+elif [ $DEFINED_XMN -ne 0 ] && [ $USING_CMS -eq 0 ]; then
+    JVM_OPTS="$JVM_OPTS -Xmn${HEAP_NEWSIZE}"
+fi
+
+if [ "$JVM_ARCH" = "64-Bit" ] && [ $USING_CMS -eq 0 ]; then
+    JVM_OPTS="$JVM_OPTS -XX:+UseCondCardMark"
+fi
+
+# enable assertions.  disabling this in production will give a modest
+# performance benefit (around 5%).
+JVM_OPTS="$JVM_OPTS -ea"
+
+# add the DSE loader
+JVM_OPTS="$JVM_OPTS $DSE_OPTS"
+
+# Per-thread stack size.
+JVM_OPTS="$JVM_OPTS -Xss256k"
+
+# Make sure all memory is faulted and zeroed on startup.
+# This helps prevent soft faults in containers and makes
+# transparent hugepage allocation more effective.
+JVM_OPTS="$JVM_OPTS -XX:+AlwaysPreTouch"
+
+# Biased locking does not benefit Cassandra.
+JVM_OPTS="$JVM_OPTS -XX:-UseBiasedLocking"
+
+# Larger interned string table, for gossip's benefit (CASSANDRA-6410)
+JVM_OPTS="$JVM_OPTS -XX:StringTableSize=1000003"
+
+# Enable thread-local allocation blocks and allow the JVM to automatically
+# resize them at runtime.
+JVM_OPTS="$JVM_OPTS -XX:+UseTLAB -XX:+ResizeTLAB"
+
+# http://www.evanjones.ca/jvm-mmap-pause.html
+JVM_OPTS="$JVM_OPTS -XX:+PerfDisableSharedMem"
+
+# provides hints to the JIT compiler
+JVM_OPTS="$JVM_OPTS -XX:CompileCommandFile=$CASSANDRA_CONF/hotspot_compiler"
+
+# add the jamm javaagent
+JVM_OPTS="$JVM_OPTS -javaagent:$CASSANDRA_HOME/lib/jamm-0.3.0.jar"
+
+# enable thread priorities, primarily so we can give periodic tasks
+# a lower priority to avoid interfering with client workload
+JVM_OPTS="$JVM_OPTS -XX:+UseThreadPriorities"
+# allows lowering thread priority without being root.  see
+# http://tech.stolsvik.com/2010/01/linux-java-thread-priorities-workaround.html
+JVM_OPTS="$JVM_OPTS -XX:ThreadPriorityPolicy=42"
+
+# set jvm HeapDumpPath with CASSANDRA_HEAPDUMP_DIR
+JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+if [ "x$CASSANDRA_HEAPDUMP_DIR" != "x" ]; then
+    JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"
+fi
+
+# uncomment to have Cassandra JVM listen for remote debuggers/profilers on port 1414
+# JVM_OPTS="$JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1414"
+
+# uncomment to have Cassandra JVM log internal method compilation (developers only)
+# JVM_OPTS="$JVM_OPTS -XX:+UnlockDiagnosticVMOptions -XX:+LogCompilation"
+# JVM_OPTS="$JVM_OPTS -XX:+UnlockCommercialFeatures -XX:+FlightRecorder"
+
+# Prefer binding to IPv4 network intefaces (when net.ipv6.bindv6only=1). See
+# http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6342561 (short version:
+# comment out this entry to enable IPv6 support).
+JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=true"
+
+# jmx: metrics and administration interface
+#
+# add this if you're having trouble connecting:
+# JVM_OPTS="$JVM_OPTS -Djava.rmi.server.hostname=<public name>"
+<% if node['cassandra']['forcermi'] %>
+JVM_OPTS="$JVM_OPTS -Djava.rmi.server.hostname=<%=node['ipaddress']%>"
+<% end %>
+#
+# see
+# https://blogs.oracle.com/jmxetc/entry/troubleshooting_connection_problems_in_jconsole
+# for more on configuring JMX through firewalls, etc. (Short version:
+# get it working with no firewall first.)
+#
+# Cassandra ships with JMX accessible *only* from localhost.
+# To enable remote JMX connections, uncomment lines below
+# with authentication and/or ssl enabled. See https://wiki.apache.org/cassandra/JmxSecurity
+#
+if [ "x$LOCAL_JMX" = "x" ]; then
+    LOCAL_JMX=yes
+fi
+
+# Specifies the default port over which Cassandra will be available for
+# JMX connections.
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+JMX_PORT="7199"
+
+if [ "$LOCAL_JMX" = "yes" ]; then
+  JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.local.port=$JMX_PORT -XX:+DisableExplicitGC"
+else
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT"
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.password.file=/etc/dse/cassandra/jmxremote.password"
+#  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.keyStore=/path/to/keystore"
+#  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.keyStorePassword=<keystore-password>"
+#  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.trustStore=/path/to/truststore"
+#  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.trustStorePassword=<truststore-password>"
+#  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.need.client.auth=true"
+#  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.registry.ssl=true"
+#  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.enabled.protocols=<enabled-protocols>"
+#  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.enabled.cipher.suites=<enabled-cipher-suites>"
+fi
+
+# To use mx4j, an HTML interface for JMX, add mx4j-tools.jar to the lib/
+# directory.
+# See http://wiki.apache.org/cassandra/Operations#Monitoring_with_MX4J
+# By default mx4j listens on 0.0.0.0:8081. Uncomment the following lines
+# to control its listen address and port.
+#MX4J_ADDRESS="-Dmx4jaddress=127.0.0.1"
+#MX4J_PORT="-Dmx4jport=8081"
+
+# Cassandra uses SIGAR to capture OS metrics CASSANDRA-7838
+# for SIGAR we have to set the java.library.path
+# to the location of the native libraries.
+JVM_OPTS="$JVM_OPTS -Djava.library.path=$JAVA_LIBRARY_PATH"
+
+# Metrics reporter support
+<% if node['cassandra']['metrics_reporter']['enabled'] %>
+JVM_OPTS="$JVM_OPTS -Dcassandra.metricsReporterConfigFile=cassandra-metrics.yaml"
+<% end %>
+
+JVM_OPTS="$JVM_OPTS $MX4J_ADDRESS"
+JVM_OPTS="$JVM_OPTS $MX4J_PORT"
+JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"

--- a/templates/default/cassandra-jvm.options.erb
+++ b/templates/default/cassandra-jvm.options.erb
@@ -1,0 +1,116 @@
+###########################################################################
+#                             jvm.options                                 #
+#                                                                         #
+# - all flags defined here will be used by cassandra to startup the JVM   #
+# - one flag should be specified per line                                 #
+# - lines that do not start with '-' will be ignored                      #
+# - only static flags are accepted (no variables or parameters)           #
+# - dynamic flags will be appended to these on cassandra-env              #
+###########################################################################
+
+#################
+# HEAP SETTINGS #
+#################
+
+# Heap size is automatically calculated by cassandra-env based on this
+# formula: max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+# That is:
+# - calculate 1/2 ram and cap to 1024MB
+# - calculate 1/4 ram and cap to 8192MB
+# - pick the max
+#
+# For production use you may wish to adjust this for your environment.
+# If that's the case, uncomment the -Xmx and Xms options below to override the
+# automatic calculation of JVM heap memory.
+#
+# It is recommended to set min (-Xms) and max (-Xmx) heap sizes to
+# the same value to avoid stop-the-world GC pauses during resize, and
+# so that we can lock the heap in memory on startup to prevent any
+# of it from being swapped out.
+<% if node['cassandra']['solr'] %>
+-Xmx<%= node['solr']['max_heap_size'] %>
+-Xms<%= node['solr']['heap_newsize'] %>
+<% elsif node['cassandra']['hadoop'] %>
+-Xmx<%= node['hadoop']['max_heap_size'] %>
+-Xms<%= node['hadoop']['heap_newsize'] %>
+<% else %>
+-Xmx<%= node['cassandra']['max_heap_size'] %>
+-Xms<%= node['cassandra']['heap_newsize'] %>
+<% end %>
+
+# Young generation size is automatically calculated by cassandra-env
+# based on this formula: min(100 * num_cores, 1/4 * heap size)
+#
+# The main trade-off for the young generation is that the larger it
+# is, the longer GC pause times will be. The shorter it is, the more
+# expensive GC will be (usually).
+#
+# It is not recommended to set the young generation size if using the
+# G1 GC, since that will override the target pause-time goal.
+# More info: http://www.oracle.com/technetwork/articles/java/g1gc-1984535.html
+#
+# The example below assumes a modern 8-core+ machine for decent
+# times. If in doubt, and if you do not particularly want to tweak, go
+# 100 MB per physical CPU core.
+#-Xmn800M
+
+#################
+#  GC SETTINGS  #
+#################
+
+### CMS Settings (comment out the G1 section and uncomment section below to enable)
+
+#-XX:+UseParNewGC
+#-XX:+UseConcMarkSweepGC
+#-XX:+CMSParallelRemarkEnabled
+#-XX:SurvivorRatio=8
+#-XX:MaxTenuringThreshold=1
+#-XX:CMSInitiatingOccupancyFraction=75
+#-XX:+UseCMSInitiatingOccupancyOnly
+#-XX:CMSWaitDuration=10000
+#-XX:+CMSParallelInitialMarkEnabled
+#-XX:+CMSEdenChunksRecordAlways
+## some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
+#-XX:+CMSClassUnloadingEnabled
+
+### G1 Settings
+
+# Use the Hotspot garbage-first collector.
+-XX:+UseG1GC
+
+# Have the JVM do less remembered set work during STW, instead
+# preferring concurrent GC. Reduces p99.9 latency.
+-XX:G1RSetUpdatingPauseTimePercent=5
+
+# Main G1GC tunable: lowering the pause target will lower throughput and vise versa.
+# 200ms is the JVM default and lowest viable setting
+# 1000ms increases throughput. Keep it smaller than the timeouts in cassandra.yaml.
+-XX:MaxGCPauseMillis=500
+
+## Optional G1 Settings
+
+# Save CPU time on large (>= 16GB) heaps by delaying region scanning
+# until the heap is 70% full. The default in Hotspot 8u40 is 40%.
+#-XX:InitiatingHeapOccupancyPercent=70
+
+# For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
+# Otherwise equal to the number of cores when 8 or less.
+# Machines with > 10 cores should try setting these to <= full cores.
+#-XX:ParallelGCThreads=16
+# By default, ConcGCThreads is 1/4 of ParallelGCThreads.
+# Setting both to the same value can reduce STW durations.
+#-XX:ConcGCThreads=16
+
+### GC logging options -- uncomment to enable
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCDateStamps
+#-XX:+PrintHeapAtGC
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+#-XX:+PrintPromotionFailure
+#-XX:PrintFLSStatistics=1
+#-Xloggc:/var/log/cassandra/gc.log
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=10
+#-XX:GCLogFileSize=10M

--- a/templates/default/cassandra_yaml/cassandra_5.0.0-1.yaml.erb
+++ b/templates/default/cassandra_yaml/cassandra_5.0.0-1.yaml.erb
@@ -506,7 +506,11 @@ ssl_storage_port: 7001
 # you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
 # address will be used. If true the first ipv6 address will be used. Defaults to false preferring
 # ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+<% if node[:cassandra][:listen_interface].nil? %>
 listen_address: <%= node[:cassandra][:listen_address] %> # localhost
+<% else %>
+listen_interface: <%= node[:cassandra][:listen_interface] %> #eth0
+<% end %>
 # listen_interface_prefer_ipv6: false
 
 # Address to broadcast to other Cassandra nodes
@@ -580,7 +584,11 @@ start_rpc: true
 # you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
 # address will be used. If true the first ipv6 address will be used. Defaults to false preferring
 # ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+<% if node[:cassandra][:rpc_interface].nil? %>
 rpc_address: <%= node[:cassandra][:rpc_address] %> # localhost
+<% else %>
+rpc_interface: <%= node[:cassandra][:rpc_interface] %> # eth0
+<% end %>
 # rpc_interface_prefer_ipv6: false
 
 # port for Thrift to listen for clients on

--- a/templates/default/cassandra_yaml/cassandra_5.0.0-1.yaml.erb
+++ b/templates/default/cassandra_yaml/cassandra_5.0.0-1.yaml.erb
@@ -1,0 +1,999 @@
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: '<%= node[:cassandra][:cluster_name] %>' #'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+num_tokens: <%=node[:cassandra][:num_tokens]%> # 128
+
+# Triggers automatic allocation of num_tokens tokens for this node. The allocation
+# algorithm attempts to choose tokens in a way that optimizes replicated load over
+# the nodes in the datacenter for the replication strategy used by the specified
+# keyspace.
+#
+# The load assigned to each node will be close to proportional to its number of
+# vnodes.
+#
+# Only supported with the Murmur3Partitioner.
+# allocate_tokens_for_keyspace: KEYSPACE
+
+# initial_token allows you to specify tokens manually.  While you can use # it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a
+# comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+# that do not have vnodes enabled.
+<% if node[:cassandra][:vnodes] %>
+# initial_token:
+<% else %>
+initial_token: <%= node[:cassandra][:initial_token] %>
+<% end %>
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+# May either be "true" or "false" to enable globally
+hinted_handoff_enabled: true
+# When hinted_handoff_enabled is true, a black list of data centers that will not
+# perform hinted handoff
+#hinted_handoff_disabled_datacenters:
+#    - DC1
+#    - DC2
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Directory where Cassandra should store hints.
+# If not set, the default directory is $CASSANDRA_HOME/data/hints.
+hints_directory: /var/lib/cassandra/hints
+
+# How often hints should be flushed from the internal buffers to disk.
+# Will *not* trigger fsync.
+hints_flush_period_in_ms: 10000
+
+# Maximum size for a single hints file, in megabytes.
+max_hints_file_size_in_mb: 128
+
+# Compression to apply to the hint files. If omitted, hints files
+# will be written uncompressed. LZ4, Snappy, and Deflate compressors
+# are supported.
+#hints_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+# DataStax Enterprise (DSE) also provides the DseAuthenticator for external authentication
+# with Kerberos and LDAP as well as internal authentication.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+#   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
+# - com.datastax.bdp.cassandra.auth.DseAuthenticator For external authentication
+#   with multiple authentication schemes. Additional configuration is required in dse.yaml.
+#   If using DseAuthenticator, DseRoleManager must also be used (see below)
+<% if node[:cassandra][:authentication] %>
+authenticator: <%= node[:cassandra][:authenticator] %>
+<% else %>
+authenticator: AllowAllAuthenticator
+<% end %>
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+# DataStax Enterprise (DSE) also provides the DseAuthorizer which must be used in place
+# of the CassandraAuthorizer if the DseAuthenticator is being used
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+# - com.datastax.bdp.cassandra.auth.DseAuthorizer for enhanced permission management of
+#   DSE specific resources. Additional configuration is required in dse.yaml
+<% if node[:cassandra][:authorization] %>
+authorizer: <%= node[:cassandra][:authorizer] %>
+<% else %>
+authorizer: AllowAllAuthorizer
+<% end %>
+
+# Part of the Authentication & Authorization backend, implementing IRoleManager; used
+# to maintain grants and memberships between roles.
+# Out of the box, Cassandra provides org.apache.cassandra.auth.CassandraRoleManager,
+# which stores role information in the system_auth keyspace. Most functions of the
+# IRoleManager require an authenticated login, so unless the configured IAuthenticator
+# actually implements authentication, most of this functionality will be unavailable.
+# DataStax Enterprise (DSE) also provides the DseRoleManager that supports LDAP roles
+# as well as the internal roles supported by CassandraRoleManager.
+#
+# - CassandraRoleManager stores role data in the system_auth keyspace. Please
+#   increase system_auth keyspace replication factor if you use this role manager.
+# - DseRoleManager stores role options in the dse_security keyspace. Please
+#   increase the dse_security keyspace replication factor if you use this role
+#   manager. Additional configuration is required in dse.yaml
+role_manager: com.datastax.bdp.cassandra.auth.DseRoleManager
+
+# Validity period for roles cache (fetching permissions can be an
+# expensive operation depending on the authorizer). Granted roles are cached for
+# authenticated sessions in AuthenticatedUser and after the period specified
+# here, become eligible for (async) reload.
+# Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthenticator.
+roles_validity_in_ms: 2000
+
+# Refresh interval for roles cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If roles_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as roles_validity_in_ms.
+# roles_update_interval_in_ms: 1000
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 1000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+data_file_directories:
+    <% @dir.each do |dirs| %>
+    - <%= dirs %>
+    <% end %>
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+commitlog_directory: <%= node[:cassandra][:commit_dir]  %>
+
+# policy for data disk failures:
+# die: shut down gossip and client transports and kill the JVM for any fs errors or
+#      single-sstable errors, so the node can be replaced.
+# stop_paranoid: shut down gossip and client transports even for single-sstable errors,
+#                kill the JVM for errors during startup.
+# stop: shut down gossip and client transports, leaving the node effectively dead, but
+#       can still be inspected via JMX, kill the JVM for errors during startup.
+# best_effort: stop using the failed disk and respond to requests based on
+#              remaining available sstables.  This means you WILL see obsolete
+#              data at CL.ONE!
+# ignore: ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# policy for commit disk failures:
+# die: shut down gossip and Thrift and kill the JVM, so the node can be replaced.
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# stop_commit: shutdown the commit log, letting writes collect but
+#              continuing to service reads, as in pre-2.0.5 Cassandra
+# ignore: ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Row cache implementation class name.
+# Available implementations:
+#   org.apache.cassandra.cache.OHCProvider                Fully off-heap row cache implementation (default).
+#   org.apache.cassandra.cache.SerializingCacheProvider   This is the row cache implementation availabile
+#                                                         in previous releases of Cassandra.
+# row_cache_class_name: org.apache.cassandra.cache.OHCProvider
+
+# Maximum size of the row cache in memory.
+# Please note that OHC cache implementation requires some additional off-heap memory to manage
+# the map structures and some in-flight memory during operations before/after cache entries can be
+# accounted against the cache capacity. This overhead is usually small compared to the whole capacity.
+# Do not specify more memory that the system can afford in the worst usual situation and leave some
+# headroom for OS block level cache. Do never allow your system to swap.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should save the row cache.
+# Caches are saved to saved_caches_directory as specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save.
+# Specify 0 (which is the default), meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: 7200
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+saved_caches_directory: <%= File.join(node.cassandra.root_dir, 'saved_caches') %>
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+# Max mutation size is also configurable via max_mutation_size_in_kb setting in
+# cassandra.yaml. The default is half the size commitlog_segment_size_in_mb * 1024.
+#
+# NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
+# be set to at least twice the size of max_mutation_size_in_kb / 1024
+#
+commitlog_segment_size_in_mb: 32
+
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.  LZ4, Snappy, and Deflate compressors
+# are supported.
+#commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+    # Addresses of hosts that are deemed contact points.
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          - seeds: "<%= node[:cassandra][:seeds] %>"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: <%= node[:cassandra][:concurrent_reads] %> #32
+concurrent_writes: <%= node[:cassandra][:concurrent_writes] %> #32
+concurrent_counter_writes: 32
+
+# For materialized view writes, as there is a read involved, so this should
+# be limited by the less of concurrent reads or concurrent writes.
+concurrent_materialized_view_writes: 32
+
+# Maximum memory to use for pooling sstable buffers. Defaults to the smaller
+# of 1/4 of heap or 512MB. This pool is allocated off-heap, so is in addition
+# to the memory allocated for heap. Memory is only allocated as needed.
+# file_cache_size_in_mb: 512
+
+# Flag indicating whether to allocate on or off heap when the sstable buffer
+# pool is exhausted, that is when it has exceeded the maximum memory
+# file_cache_size_in_mb, beyond which it will not cache buffers but allocate on request.
+
+# buffer_pool_use_heap_if_exhausted: true
+
+# The strategy for optimizing disk read
+# Possible values are:
+# ssd (for solid state disks, the default)
+# spinning (for spinning disks)
+# disk_optimization_strategy: ssd
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable. Larger mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#   heap_buffers:    on heap nio buffers
+#   offheap_buffers: off heap (direct) nio buffers
+memtable_allocation_type: heap_buffers
+
+# Total space to use for commit logs on disk.
+#
+# If space gets above this value, Cassandra will flush every dirty CF
+# in the oldest segment and remove it.  So a small total commitlog space
+# will tend to cause more flush activity on less-active columnfamilies.
+#
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+#
+# commitlog_total_space_in_mb: 8192
+
+# This sets the amount of memtable flush writer threads.  These will
+# be blocked by disk io, and each one will hold a memtable in memory
+# while blocked.
+#
+# memtable_flush_writers defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+<% if node["cassandra"]["memtable_flush_writers"] %>
+memtable_flush_writers: <%= node["cassandra"]["memtable_flush_writers"] %>
+<% else %>
+#memtable_flush_writers: 8
+<% end %>
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb:
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: 60
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+<% if node[:cassandra][:trickle_fsync] %>
+trickle_fsync: true
+<% else %>
+trickle_fsync: false
+<% end %>
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+ssl_storage_port: 7001
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+listen_address: <%= node[:cassandra][:listen_address] %> # localhost
+# listen_interface_prefer_ipv6: false
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+rpc_address: <%= node[:cassandra][:rpc_address] %> # localhost
+
+# When using multiple physical network interfaces, set this
+# to true to listen on broadcast_address in addition to
+# the listen_address, allowing nodes to communicate in both
+# interfaces.
+# Ignore this property if the network configuration automatically
+# routes  between the public and private networks such as EC2.
+# listen_on_broadcast_address: false
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+native_transport_port: 9042
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+# native_transport_port_ssl: 9142
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB. If you're changing this parameter,
+# you may want to adjust max_value_size_in_mb accordingly.
+# native_transport_max_frame_size_in_mb: 256
+
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+
+# Whether to start the thrift rpc server.
+start_rpc: true
+
+# The address or interface to bind the Thrift RPC service and native transport
+# server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: <%= node[:cassandra][:rpc_address] %> # localhost
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+<%= !node['cassandra']['broadcast_rpc_address'].nil? ? "broadcast_rpc_address: #{node['cassandra']['broadcast_rpc_address']}" : "# broadcast_rpc_address: 1.2.3.4"%>
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync  -> One thread per thrift connection. For a very large number of clients, memory
+#          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#          per thread, and that will correspond to your use of virtual memory (but physical memory
+#          may be limited depending on use of stack space).
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#          asynchronously using a small number of threads that does not vary with the amount
+#          of thrift clients (and thus scales well to many clients). The rpc requests are still
+#          synchronous (one thread per active request). If hsha is selected then it is essential
+#          that rpc_max_threads is changed from the default value of unlimited.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and: man tcp
+# internode_send_buff_size_in_bytes:
+# internode_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum message length).
+thrift_framed_transport_size_in_mb: <%= node['cassandra']['thrift_framed_transport_size_in_mb'] %> # 15
+<% if node['cassandra']['thrift_max_message_length_in_mb'] %>
+thrift_max_message_length_in_mb: <%= node['cassandra']['thrift_max_message_length_in_mb'] %>
+<% else %>
+<% end %>
+
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows withing the partition by collation column
+#      is faster
+#   2) but, Cassandra will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+column_index_size_in_kb: 64
+
+
+# Log WARN on any batch size exceeding this value. 64kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 64
+
+# Fail any batch exceeding this value. 640kb (10x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 640
+
+# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
+unlogged_batch_across_partitions_warn_threshold: 10
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+<% if node[:cassandra][:concurrent_compactors] %>
+concurrent_compactors: <%= node[:cassandra][:concurrent_compactors] %>
+<% else %>
+#concurrent_compactors: 1
+<% end %>
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: <%= node[:cassandra][:compaction_thruput] %> # 16
+
+# Log a warning when compacting partitions larger than this value
+compaction_large_partition_warning_threshold_mb: <%= node[:cassandra][:compaction_large_partition_warning_threshold_mb] %> # 100
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: 50
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# When unset, the default is 200 Mbps or 25 MB/s
+# inter_dc_stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: <%= node['cassandra']['read_request_timeout_in_ms'] %>
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: <%= node['cassandra']['range_request_timeout_in_ms'] %> # 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: <%= node['cassandra']['write_request_timeout_in_ms'] %>
+# How long the coordinator should wait for counter writes to complete
+counter_write_request_timeout_in_ms: <%= node['cassandra']['counter_request_timeout_in_ms'] %> # 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: <%= node['cassandra']['cas_retention_request_timeout_in_ms'] %> # 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: <%= node['cassandra']['truncate_request_timeout_in_ms'] %> # 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: <%= node['cassandra']['request_timeout_in_ms'] %> # 10000
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Set socket timeout for streaming operation.
+# The stream session is failed if no data/ack is received by any of the participants
+# within that period, which means this should also be sufficient to stream a large
+# sstable or rebuild table indexes.
+# Default value is 86400000ms, which means stale streams timeout after 24 hours.
+# A value of zero means stream sockets should never time out.
+# streaming_socket_timeout_in_ms: 86400000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# IF THE RACK A REPLICA IS PLACED IN CHANGES AFTER THE REPLICA HAS BEEN
+# ADDED TO A RING, THE NODE MUST BE DECOMMISSIONED AND REBOOTSTRAPPED.
+#
+# Out of the box, Cassandra provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+# DataStax Enterprise (DSE) provides
+#  - com.datastax.bdp.snitch.DseSimpleSnitch:
+#    Proximity is determined by DSE workload, which places Cassandra,
+#    Analytics, and Solr nodes into their separate datacenters.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: <%= node[:cassandra][:dse][:snitch] %> # com.datastax.bdp.snitch.DseSimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+# NoScheduler - Has no options
+# RoundRobin
+#  - throttle_limit -- The throttle_limit is the number of in-flight
+#                      requests per client.  Requests beyond
+#                      that limit are queued up until
+#                      running requests can complete.
+#                      The value of 80 here is twice the number of
+#                      concurrent_reads + concurrent_writes.
+#  - default_weight -- default_weight is optional and allows for
+#                      overriding the default which is 1.
+#  - weights -- Weights are optional and will default to 1 or the
+#               overridden default_weight. The weight translates into how
+#               many requests are handled during each turn of the
+#               RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# Use the DHE/ECDHE ciphers if running in FIPS 140 compliant mode.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+    internode_encryption: <%= node["cassandra"]["dse"]["internode_encryption"] %> # none
+    keystore: <%= node["cassandra"]["dse"]["keystore"] %> # resources/dse/conf/.keystore
+    keystore_password: <%= @ssl_password.call %> # cassandra
+    truststore: <%= node["cassandra"]["dse"]["truststore"] %> # resources/dse/conf/.truststore
+    truststore_password: <%= @ssl_password.call %> # cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+    # require_client_auth: false
+
+# enable or disable client/server encryption.
+client_encryption_options:
+    enabled: <%= node["cassandra"]["dse"]["client_encryption_enabled"] %>
+    # If enabled and optional is set to true encrypted and unencrypted connections are handled.
+    optional: false
+    keystore: <%= node["cassandra"]["dse"]["keystore"] %>
+    keystore_password: <%= @ssl_password.call %>
+    # require_client_auth: false
+    # Set trustore and truststore_password if require_client_auth is true
+    # truststore: resources/dse/conf/.truststore
+    # truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+internode_compression: dc
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false
+
+# TTL for different trace types used during logging of the repair process.
+tracetype_query_ttl: 86400
+tracetype_repair_ttl: 604800
+
+# GC Pauses greater than gc_warn_threshold_in_ms will be logged at WARN level
+# Adjust the threshold based on your application throughput requirement
+# By default, Cassandra logs GC Pauses greater than 200 ms at INFO level
+gc_warn_threshold_in_ms: 1000
+
+# UDFs (user defined functions) are disabled by default.
+# As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
+enable_user_defined_functions: false
+
+# Enables scripted UDFs (JavaScript UDFs).
+# Java UDFs are always enabled, if enable_user_defined_functions is true.
+# Enable this option to be able to use UDFs with "language javascript" or any custom JSR-223 provider.
+# This option has no effect, if enable_user_defined_functions is false.
+enable_scripted_user_defined_functions: false
+
+# The default Windows kernel timer and scheduling resolution is 15.6ms for power conservation.
+# Lowering this value on Windows can provide much tighter latency and better throughput, however
+# some virtualized environments may see a negative performance impact from changing this setting
+# below their system default. The sysinternals 'clockres' tool can confirm your system's default
+# setting.
+windows_timer_interval: 1
+
+# Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
+# early. Any value size larger than this threshold will result into marking an SSTable
+# as corrupted.
+# max_value_size_in_mb: 256

--- a/templates/default/dse/dse_5.0.0-1.erb
+++ b/templates/default/dse/dse_5.0.0-1.erb
@@ -1,0 +1,82 @@
+# NOTICE: See also /etc/dse/cassandra/cassandra-env.sh
+
+# EXTRA_CLASSPATH provides the means to extend Cassandra's classpath with
+# additional libraries.  It is formatted as a colon-delimited list of
+# class directories and/or jar files.  For example, to enable the
+# JMX-to-web bridge install libmx4j-java and uncomment the following.
+#EXTRA_CLASSPATH="/usr/share/java/mx4j-tools.jar"
+
+# Start the node in Hadoop mode
+# Note: Hadoop functionality is deprecated and may be removed in a future release
+<% if node[:cassandra][:hadoop] %>
+HADOOP_ENABLED=1
+<% else %>
+HADOOP_ENABLED=0
+<% end %>
+
+# Enable the DSE Graph service on this node
+<% if node[:cassandra][:graph] %>
+GRAPH_ENABLED=1
+<% else %>
+GRAPH_ENABLED=0
+<% end %>
+
+# Set the replication factor for CFS.  Note that this will only have an effect
+# the first time a cluster is started with Hadoop or Spark enabled; after that
+# it will be a no-op. Defaults to 1.
+#CFS_REPLICATION_FACTOR=1
+
+# Start the node in DSE Search mode
+<% if node[:cassandra][:solr] %>
+SOLR_ENABLED=1
+<% else %>
+SOLR_ENABLED=0
+<% end %>
+
+# Start the node in Spark mode
+<% if node[:cassandra][:spark] %>
+SPARK_ENABLED=1
+<% else %>
+SPARK_ENABLED=0
+<% end %>
+
+# Enable this to start CFS; CFS is automatically started on any node started
+# with Spark or Hadoop; setting this to 1 enables CFS regardless of the node
+# type
+CFS_ENABLED=0
+
+# Determine install root location (applicable for standalone installer or
+# Debian/RedHat packages; not used in tarball installs)
+if [ -d /usr/share/dse ]; then
+    export DSE_HOME=/usr/share/dse
+fi
+# Set this if you've installed to a location different from the default
+#DSE_HOME=your_install_location
+
+# Location of log output
+OUTPUT_FILE="/var/log/cassandra/output.log"
+
+# Configuration directory
+CASSANDRA_CONF=/etc/dse/cassandra
+
+# Set the PID file location here
+PIDFILE=/var/run/$NODEID/$NODEID.pid
+
+# Where do Hadoop log files go? This will override the default
+#HADOOP_LOG_DIR=
+
+# Where do Tomcat log files go? This will override the default
+#TOMCAT_LOGS=
+
+# The user to use for the service
+CASSANDRA_USER=<%= node[:cassandra][:user] %>
+
+# The group to use for the service
+CASSANDRA_GROUP=<%= node[:cassandra][:group] %>
+
+# Set this if you've installed DSE into a different location from the default
+# (Note: this refers to DSE Spark, not open-source Spark)
+#SPARK_HOME=your_spark_install_location
+
+# Spark configuration files location
+SPARK_CONF_DIR=/etc/dse/spark

--- a/templates/default/dse_yaml/dse_5.0.0-1.yaml.erb
+++ b/templates/default/dse_yaml/dse_5.0.0-1.yaml.erb
@@ -1,0 +1,996 @@
+# Memory limit for DSE In-Memory tables as a fraction of system memory (the default is 0.2, or 20%)
+max_memory_to_lock_fraction: 0.20
+
+# Can also be specified as a maximum in MB; the fraction value is ignored if this is set to a non-zero value.
+# max_memory_to_lock_mb: 10240
+
+# Enable the Hive Meta Store via Cassandra
+hive_meta_store_enabled: true
+
+# Authentication options
+#
+# These options are used if the authenticator option in cassandra.yaml is set to
+# com.datastax.bdp.cassandra.auth.DseAuthenticator
+#
+# The enabled option controls whether the DseAuthenticator will authenticate users. If
+# set to true users will be authenticated, if set to false they will not.
+#
+# DseAuthenticator allows multiple authentication schemes to be used at the same time.
+# The schemes to be used are controlled by the default_scheme and allowed_schemes options.
+# A driver can select the scheme to use during authentication.
+#
+# The default_scheme option selects which authentication scheme will be used if the driver
+# does not request a specific scheme. This can be one of the following values:
+#   internal - plain text authentication using the Cassandra password authenticator
+#   ldap     - plain text authentication using the passthrough ldap authenticator
+#   kerberos - gssapi authentication using the kerberos authenticator
+# The other_schemes option is a list of schemes that can also be selected for use by a
+# driver and can be a list of the above schemes.
+#
+# The scheme_permissions option controls whether roles need to have permission granted to
+# them in order to use specific authentication schemes. These permissions can be granted
+# only when the DseAuthorizer is used.
+#
+# The allow_digest_with_kerberos option controls whether digest-md5 authentication is also
+# allowed when kerberos is one of the authentication schemes. If set to false, it will not
+# be allowed. You must set allow_digest_with_kerberos to true in analytics clusters to use Hadoop
+# inter-node authentication with Hadoop and Spark jobs.
+#
+# The plain_text_without_ssl controls how the DseAuthenticator reacts to plain text
+# authentication requests over unencrypted client connections. It can be one of:
+#   block  - block the request with an authentication error
+#   warn   - log a warning about the request but allow it to continue
+#   allow  - allow the request without any warning
+#
+# The transitional_mode option allows the DseAuthenticator to operate in a transitional
+# mode during setup of authentication in a cluster. This can be one of the following
+# values:
+#   disabled   - transitional mode is disabled
+#   permissive - Only super users are authenticated and logged in, all other
+#                authentication attempts will be logged in as the anonymous user
+#   normal     - If credentials are passed they are authenticated. If the
+#                authentication is successful then the user is logged in, otherwise
+#                the user is logged in as anonymous. If no credentials are passed,
+#                then the user is logged in as anonymous
+#   strict     - If credentials are passed they are authenticated. If the
+#                authentication is successful, the user is logged in. If the
+#                authentication fails, an authentication error is returned. If no
+#                credentials are passed, the user is logged in as anonymous
+authentication_options:
+    enabled: false
+    default_scheme: kerberos
+    other_schemes:
+      - internal
+    scheme_permissions: true
+    allow_digest_with_kerberos: true
+    plain_text_without_ssl: warn
+    transitional_mode: disabled
+
+#
+# Role Management Options
+#
+# These options are used when the role_manager option in cassandra.yaml is set to
+# com.datastax.bdp.cassandra.auth.DseRoleManager
+#
+# mode can be one of:
+#   internal - the granting and revoking of roles is managed internally
+#              using the GRANT ROLE and REVOKE ROLE statements
+#   ldap - the granting and revoking of roles is managed by an external
+#          LDAP server configured using the ldap_options.
+role_management_options:
+    mode: internal
+
+# Authorization options
+#
+# The enabled option controls whether the DseAuthorizer will perform authorization. If
+# set to true authorization is performed, if set to false it is not.
+#
+# The transitional_mode option allows the DseAuthorizer to operate in a transitional
+# mode during setup of authorization in a cluster. This can be one of the following
+# values:
+#   disabled   - transitional mode is disabled
+#   normal     - permissions can be granted to resources but are not enforced
+#   strict     - permissions can be granted to resources and are enforced on
+#                authenticated users. They are not enforced against anonymous
+#                users
+authorization_options:
+    enabled: false
+    transitional_mode: disabled
+
+# Kerberos options
+#
+# The qop is the Quality of Protection (QOP) values that clients and servers
+# can use for each connection.  Below is a list of valid values and their meanings.
+#   auth - (default) authentication only
+#   auth-int - authentication plus integity protection of all transmitted data
+#   auth-conf - authetication plus integrity protection and encryption of all
+#              transmitted data
+# Warning: Encryption using auth-conf is separate and completely independent
+# of whether encryption is done using SSL.  If auth-conf is selected here
+# and SSL is enabled, the transmitted data is encrypted twice.
+kerberos_options:
+    keytab: resources/dse/conf/dse.keytab
+    service_principal: dse/_HOST@REALM
+    http_principal: HTTP/_HOST@REALM
+    qop: auth
+
+# LDAP options
+#
+# These are options are used when the com.datastax.bdp.cassandra.auth.LdapAuthenticator
+# is configured as the authenticator in cassandra.yaml
+#
+<%= ("com.datastax.bdp.cassandra.auth.LdapAuthenticator".eql?(node['cassandra']['authenticator'])) ? "ldap_options:" : "# ldap_options:" %>
+    <%= !node['cassandra']['dse']['ldap_options']['server_host'].nil? ? "server_host: #{node['cassandra']['dse']['ldap_options']['server_host']}" : "# server_host: localhost"%>
+    # Port to use to connect to the LDAP server. This is normally 389 for unencrypted
+    # connections and 636 for ssl encrypted connections. If use_tls is set to true, use the
+    # unencrypted port
+    <%= !node['cassandra']['dse']['ldap_options']['server_port'].nil? ? "server_port: #{node['cassandra']['dse']['ldap_options']['server_port']}" : "# server_port: 389"%>
+    # The distinguished name (DN) of the user that is used to search for other users on the
+    # LDAP server. This user should have only the necessary permissions to do the search
+    # If not present then an anonymous bind is used for the search
+    <%= !node['cassandra']['dse']['ldap_options']['search_dn'].nil? ? "search_dn: #{node['cassandra']['dse']['ldap_options']['search_dn']}" : "# search_dn: cn=Admin"%>
+    # Password of the search user
+    <%= !node['cassandra']['dse']['ldap_options']['search_password'].nil? ? "search_password: #{node['cassandra']['dse']['ldap_options']['search_password']}" : "# search_password: secret"%>
+    # Set to true to use an SSL encrypted connection. In this case the server_port needs
+    # to be set to the LDAP port for the server
+    <%= !node['cassandra']['dse']['ldap_options']['use_ssl'].nil? ? "use_ssl: #{node['cassandra']['dse']['ldap_options']['use_ssl']}" : "# use_ssl: false"%>
+    # Set to true to initiate a TLS encrypted connection on the default ldap port
+    <%= !node['cassandra']['dse']['ldap_options']['use_tls'].nil? ? "use_tls: #{node['cassandra']['dse']['ldap_options']['use_tls']}" : "# use_tls: false"%>
+    <%= !node['cassandra']['dse']['ldap_options']['truststore_path'].nil? ? "truststore_path: #{node['cassandra']['dse']['ldap_options']['truststore_path']}" : "# truststore_path:"%>
+    <%= !node['cassandra']['dse']['ldap_options']['truststore_password'].nil? ? "truststore_password: #{node['cassandra']['dse']['ldap_options']['truststore_password']}" : "# truststore_password:"%>
+    <%= !node['cassandra']['dse']['ldap_options']['truststore_type'].nil? ? "truststore_type: #{node['cassandra']['dse']['ldap_options']['truststore_type']}" : "# truststore_type: jks"%>
+    <%= !node['cassandra']['dse']['ldap_options']['user_search_base'].nil? ? "user_search_base: #{node['cassandra']['dse']['ldap_options']['user_search_base']}" : "# user_search_base: ou=users,dc=example,dc=com"%>
+    <%= !node['cassandra']['dse']['ldap_options']['user_search_filter'].nil? ? "user_search_filter: #{node['cassandra']['dse']['ldap_options']['user_search_filter']}" : "# user_search_filter: (uid={0})"%>
+    # Set to the attribute on the user entry containing group membership information.
+#    user_memberof_attribute: memberof
+    # The group_search_type defines how group membership will be determined for a user. It
+    # can be one of:
+    #   directory_search - will do a subtree search of group_search_base using
+    #                      group_search_filter to filter the results
+    #   memberof_search - will get groups from the memberof attribute of the user. This
+    #                     requires the directory server to have memberof support
+#    group_search_type: directory_search
+#    group_search_base:
+#    group_search_filter: (uniquemember={0})
+    # The attribute in the group entry that holds the group name.
+#    group_name_attribute: cn
+    # Validity period for the credentials cache in milli-seconds (remote bind is an expensive
+    # operation). Defaults to 0, set to 0 to disable.
+    <%= !node['cassandra']['dse']['ldap_options']['credentials_validity_in_ms'].nil? ? "credentials_validity_in_ms: #{node['cassandra']['dse']['ldap_options']['credentials_validity_in_ms']}" : "# credentials_validity_in_ms: 0"%>
+    # Validity period for the search cache in seconds. Defaults to 0, set to 0 to disable.
+    <%= !node['cassandra']['dse']['ldap_options']['search_validity_in_seconds'].nil? ? "search_validity_in_seconds: #{node['cassandra']['dse']['ldap_options']['search_validity_in_seconds']}" : "# search_validity_in_seconds: 0"%>
+    <%= !node['cassandra']['dse']['ldap_options']['connection_pool']['max_active'].nil? || !node['cassandra']['dse']['ldap_options']['connection_pool']['max_idle'].nil? ? "connection_pool:" : "# connection_pool:"%>
+        <%= !node['cassandra']['dse']['ldap_options']['connection_pool']['max_active'].nil? ? "max_active: #{node['cassandra']['dse']['ldap_options']['connection_pool']['max_active']}" : "# max_active: 8"%>
+        <%= !node['cassandra']['dse']['ldap_options']['connection_pool']['max_idle'].nil? ? "max_idle: #{node['cassandra']['dse']['ldap_options']['connection_pool']['max_idle']}" : "# max_idle: 8"%>
+
+# To ensure that data with a TTL is purged from Solr indexes when it expires,
+# DSE periodically checks indexes for data that has exceeded its TTL. These settings
+# control the scheduling & execution of those checks.
+ttl_index_rebuild_options:
+    # by default, schedule a check every 300 seconds
+    fixed_rate_period: 300
+    # the first check is delayed to speed up startup time
+    initial_delay: 20
+    # documents subject to TTL are checked in batches: this configures the maximum number of
+    # docs checked per batch
+    max_docs_per_batch: 200
+    # maximum number of cores that can execute TTL cleanup concurrently
+    thread_pool_size: 1
+
+# Solr shard transport options, for inter-node communication between Solr nodes.
+shard_transport_options:
+#
+# Default type from 4.5.0 onwards is "netty" for TCP-based communication,
+# providing lower latency, improved throughput and reduced resource consumption.
+# The other type is "http" for plain old Solr communication via the standard
+# HTTP-based interface.
+#
+# WARNING: The "http" transport type is now deprecated and will be removed in a future release.
+    type: netty
+#
+# Options specific to the "netty" transport type.
+#
+# The TCP listen port, mandatory if you either want to use the "netty" transport
+# type, or want to later migrate to it from the "http" one. If you plan to use
+# and stay with the "http" one, either comment it out or set it to -1. Once every
+# node in the cluster is running DSE 5.0, requests coordinated by this node will
+# no longer contact other nodes on this port, but will instead use the new binary
+# protocol. This option will be removed in a future
+# release of DSE.
+    netty_server_port: 8984
+#
+# Note that the following settings apply only to the legacy Netty transport.
+# (Starting with DSE 5.0, the common messaging service is used and the configuration
+# options for it are available later in this file under internode_messaging_options.)
+#
+# The number of server acceptor threads (default is number of available processors).
+#   netty_server_acceptor_threads:
+# The number of server worker threads (default is number of available processors * 8).
+#   netty_server_worker_threads:
+# The number of client worker threads (default is number of available processors * 8).
+#   netty_client_worker_threads:
+# The max number of client connections (default is 100).
+#   netty_client_max_connections:
+# The cumulative shard request timeout, in milliseconds (default is 60000).
+#   netty_client_request_timeout:
+#
+# Options specific to the "http" transport type.
+#
+# WARNING: The "http" transport type is now deprecated and will be removed in a future release.
+#
+# HTTP shard client timeouts in milliseconds.
+# Default is the same as Solr, that is 0, meaning no timeout at all; it is
+# strongly suggested to change it to a finite value, to avoid blocking operations.
+# Notice these settings are valid across Solr cores.
+#   http_shard_client_conn_timeout: 0
+#   http_shard_client_socket_timeout: 0
+
+# Solr index encryption options.
+solr_encryption_options:
+# Whether shared Solr decryption cache should be allocated off JVM heap.
+# Default is off heap allocation (true).
+#    decryption_cache_offheap_allocation: true
+# The maximum size of shared Solr decryption cache, in MB.
+# Default is 256 MB.
+#    decryption_cache_size_in_mb: 256
+
+# Solr indexing settings
+#
+# Max number of concurrent asynchronous indexing threads per Solr core.
+# Default is "number of available processors"; if set at 1,
+# the system reverts to the synchronous behavior, where data is
+# synchronously written into Cassandra and indexed by Solr.
+#
+# max_solr_concurrency_per_core: 2
+#
+# Allows back pressure system to adapt max auto soft commit time (defined per core in solrconfig.xml) to the actual load.
+# Setting is respected only for NRT (near real time) cores. When core has RT (real time) enabled, adaptive commits
+# are disabled regardless of this property value.
+# Default is enabled (true).
+#
+# enable_back_pressure_adaptive_nrt_commit: true
+#
+# The back pressure threshold is the target total number of queued asynchronous indexing requests per core;
+# the back pressure mechanism will throttle incoming requests to keep the queue size as close to the threshold as possible.
+# Default is 1000 * "number of available processors".
+#
+# back_pressure_threshold_per_core: 1000
+#
+# The max time to wait for flushing of async index updates, happening either
+# at Solr commit time or Cassandra flush time.
+# Flushing should always complete successfully, in order to fully sync Solr indexes
+# with Cassandra data, so should always be set at a reasonable high value,
+# expressed in minutes.
+# Default is 5.
+#
+# flush_max_time_per_core: 5
+#
+# The max time to wait for each Solr core to load upon startup or create/reload operations, expressed in minutes.
+# This is an advanced option, which should be changed only if any exceptions happen during core loading.
+# Default is 5.
+# load_max_time_per_core: 5
+
+# Applies the configured Cassandra disk failure policy to index write failures.
+# Default is disabled (false).
+#
+# enable_index_disk_failure_policy: false
+
+# The directory to store index data; each Solr core index will be stored under
+# a solrconfig_data_dir/keyspace.table directory.
+# Default is a solr.data directory inside Cassandra data directory, or as specified
+# by the dse.solr.data.dir system property
+#
+#solr_data_dir: /MyDir
+
+# The Lucene field cache has been deprecated, instead set docValues="true" on the field
+# in the schema.xml file.  After doing so RELOAD the core and reindex.
+#
+# Default: false
+#
+# solr_field_cache_enabled: false
+
+# Solr cql query options
+#
+# Max number of threads to use for retrieving rows during CQL Solr queries.
+# This value is cross-request and cross-core.
+# Default is "number of available processors" * 10.
+#
+# cql_solr_query_executor_threads: 2
+#
+# Max time in milliseconds to wait for either each row (pre-5.0) or all rows (5.0 onwards)
+# to be read from Cassandra during CQL Solr queries.
+# Default is 10000 (10 seconds).
+#
+# cql_solr_query_row_timeout: 10000
+
+# Maximum number of threads used by the performance service
+#
+#performance_max_threads: 32
+
+# CQL performance objects features:
+# * CQL Slow Log
+# * CQL System Info
+# * User Level Latency Tracking
+# * Resource Level Latency Tracking
+# * Database Summary Statistics
+
+graph_events:
+  ttl_seconds: 600
+
+# CQL slow log settings
+#  threshold:        t > 1        Log queries taking longer than t milliseconds
+#                    0 <= t <= 1  Log queries above t percentile
+#  minimum_samples:  initial number of queries before percentile filter becomes active
+
+cql_slow_log_options:
+    enabled: <%= node['cassandra']['dse']['cql_slow_log_options']['enabled'] %>
+    threshold: <%= node['cassandra']['dse']['cql_slow_log_options']['threshold_ms'] %>
+    minimum_samples: <%= node['cassandra']['dse']['cql_slow_log_options']['minimum_samples'] %>
+    ttl_seconds: <%= node['cassandra']['dse']['cql_slow_log_options']['ttl_seconds'] %>
+
+# CQL system info tables settings
+cql_system_info_options:
+    enabled: <%= node['cassandra']['dse']['cql_system_info_options']['enabled'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['cql_system_info_options']['refresh_rate_ms'] %>
+
+# Data Resource latency tracking settings
+resource_level_latency_tracking_options:
+    enabled: <%= node['cassandra']['dse']['resource_level_latency_tracking_options']['enabled'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['resource_level_latency_tracking_options']['refresh_rate_ms'] %>
+
+# Database summary stats options
+db_summary_stats_options:
+    enabled: <%= node['cassandra']['dse']['db_summary_stats_options']['enabled'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['db_summary_stats_options']['refresh_rate_ms'] %>
+
+# Cluster summary stats options
+cluster_summary_stats_options:
+    enabled: <%= node['cassandra']['dse']['cluster_summary_stats_options']['enabled'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['cluster_summary_stats_options']['refresh_rate_ms'] %>
+
+# Spark cluster summary stats options
+spark_cluster_info_options:
+    enabled: <%= node['cassandra']['dse']['spark_cluster_info_options']['enabled'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['spark_cluster_info_options']['refresh_rate_ms'] %>
+
+# Spark application stats options
+spark_application_info_options:
+    enabled: <%= node['cassandra']['dse']['spark_application_info_options']['enabled'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['spark_application_info_options']['refresh_rate_ms'] %>
+    driver:
+        # enables or disables writing of the metrics collected at Spark Driver to Cassandra
+        sink: <%= node['cassandra']['dse']['spark_application_info_options']['driver']['sink'] %>
+        # enables or disables Spark Cassandra Connector metrics at Spark Driver
+        connectorSource: <%= node['cassandra']['dse']['spark_application_info_options']['driver']['connectorSource'] %>
+        # enables or disables JVM heap and GC metrics at Spark Driver
+        jvmSource: <%= node['cassandra']['dse']['spark_application_info_options']['driver']['jvmSource'] %>
+        # enables or disables application state metrics
+        stateSource: <%= node['cassandra']['dse']['spark_application_info_options']['driver']['stateSource'] %>
+    executor:
+        # enables or disables writing of the metrics collected at executors to Cassandra
+        sink: <%= node['cassandra']['dse']['spark_application_info_options']['executor']['sink'] %>
+        # enables or disables Spark Cassandra Connector metrics at executors
+        connectorSource: <%= node['cassandra']['dse']['spark_application_info_options']['executor']['connectorSource'] %>
+        # enables or disables JVM heap and GC metrics at executors
+        jvmSource: <%= node['cassandra']['dse']['spark_application_info_options']['executor']['jvmSource'] %>
+
+# Column Family Histogram data tables options
+histogram_data_options:
+  enabled: <%= node['cassandra']['dse']['histogram_data_options']['enabled'] %>
+  refresh_rate_ms: <%= node['cassandra']['dse']['histogram_data_options']['refresh_rate_ms'] %>
+  retention_count: <%= node['cassandra']['dse']['histogram_data_options']['retention_count'] %>
+
+# User/Resource latency tracking settings
+user_level_latency_tracking_options:
+   enabled: <%= node['cassandra']['dse']['user_level_latency_tracking_options']['enabled'] %>
+   refresh_rate_ms: <%= node['cassandra']['dse']['user_level_latency_tracking_options']['refresh_rate_ms'] %>
+   top_stats_limit: <%= node['cassandra']['dse']['user_level_latency_tracking_options']['top_stats_limit'] %>
+   quantiles: <%= node['cassandra']['dse']['user_level_latency_tracking_options']['quantiles'] %>
+
+# Solr Performance Objects
+
+# Solr indexing error log options
+solr_indexing_error_log_options:
+    enabled: <%= node['cassandra']['dse']['solr_indexing_error_log_options']['enabled'] %>
+    ttl_seconds: <%= node['cassandra']['dse']['solr_indexing_error_log_options']['ttl_seconds'] %>
+    async_writers: <%= node['cassandra']['dse']['solr_indexing_error_log_options']['async_writers'] %>
+   
+# Solr slow query log options
+solr_slow_sub_query_log_options:
+    enabled: <%= node['cassandra']['dse']['solr_slow_sub_query_log_options']['enabled'] %>
+    ttl_seconds: <%= node['cassandra']['dse']['solr_slow_sub_query_log_options']['ttl_seconds'] %>
+    async_writers: <%= node['cassandra']['dse']['solr_slow_sub_query_log_options']['async_writers'] %>
+    threshold_ms: <%= node['cassandra']['dse']['solr_slow_sub_query_log_options']['threshold_ms'] %>
+
+# Solr UpdateHandler metrics options
+solr_update_handler_metrics_options:
+    enabled: <%= node['cassandra']['dse']['solr_update_handler_metrics_options']['enabled'] %>
+    ttl_seconds: <%= node['cassandra']['dse']['solr_update_handler_metrics_options']['ttl_seconds'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['solr_update_handler_metrics_options']['refresh_rate_ms'] %>
+
+# Solr request handler metrics options
+solr_request_handler_metrics_options:
+    enabled: <%= node['cassandra']['dse']['solr_request_handler_metrics_options']['enabled'] %>
+    ttl_seconds: <%= node['cassandra']['dse']['solr_request_handler_metrics_options']['ttl_seconds'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['solr_request_handler_metrics_options']['refresh_rate_ms'] %>
+
+# Solr index statistics options
+solr_index_stats_options:
+    enabled: <%= node['cassandra']['dse']['solr_index_stats_options']['enabled'] %>
+    ttl_seconds: <%= node['cassandra']['dse']['solr_index_stats_options']['ttl_seconds'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['solr_index_stats_options']['refresh_rate_ms'] %>
+
+# Solr cache statistics options
+solr_cache_stats_options:
+    enabled: <%= node['cassandra']['dse']['solr_cache_stats_options']['enabled'] %>
+    ttl_seconds: <%= node['cassandra']['dse']['solr_cache_stats_options']['ttl_seconds'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['solr_cache_stats_options']['refresh_rate_ms'] %>
+    
+# Solr latency snapshot options
+solr_latency_snapshot_options:
+    enabled: <%= node['cassandra']['dse']['solr_latency_snapshot_options']['enabled'] %>
+    ttl_seconds: <%= node['cassandra']['dse']['solr_latency_snapshot_options']['ttl_seconds'] %>
+    refresh_rate_ms: <%= node['cassandra']['dse']['solr_latency_snapshot_options']['refresh_rate_ms'] %>
+
+# Node health is a score-based representation of how fit a node is to handle queries. The score is a
+# function of how long a node has been up and the rate of dropped mutations in the recent past.
+node_health_options:
+    refresh_rate_ms: <%= node['cassandra']['dse']['node_health_options']['refresh_rate_ms'] %>
+    # The amount of continuous uptime required for the node's uptime score to
+    # advance from 0 to 1. (Default: 86400 seconds, or 1 day)
+    #
+    # (Default: 86400 seconds, or 1 day)
+    uptime_ramp_up_period_seconds: 86400
+    # The window in the past over which the rate of dropped mutations affects the node health score.
+    # (Default: 30 minutes)
+    dropped_mutation_window_minutes: 30
+
+# If enabled (true), replica selection for distributed Solr queries takes node health into account
+# when multiple candidates exist for a particular token range. Set this to false to ignore
+# node health when choosing replicas.
+#
+# Health-based routing allows us to make a trade-off between index consistency and query throughput. If
+# the primary concern is query performance, it may make sense to set this to "false".
+#
+# Default is enabled (true).
+enable_health_based_routing: true
+
+# Lease metrics. Enable these to help monitor the performance of the lease subsystem.
+# ttl_seconds controls how long the log of lease holder changes persists.
+lease_metrics_options:
+    enabled: false
+    ttl_seconds: 604800
+
+# The directory where system keys are kept
+#
+# Keys used for sstable encryption must be distributed to all nodes
+# DSE must be able to read and write to the directory.
+#
+# This directory should have 700 permissions and belong to the dse user
+system_key_directory: <%= node['cassandra']['dse']['system_key_directory'] %>
+
+# If this is set to true, DSE will expect the following config values to be encrypted:
+#   resources/cassandra/conf/cassandra.yaml:
+#     server_encryption_options.keystore_password
+#     server_encryption_options.truststore_password
+#     client_encryption_options.keystore_password
+#     client_encryption_options.truststore_password
+#   resources/dse/conf/dse.yaml:
+#     ldap_options.search_password
+#     ldap_options.truststore_password
+#
+# it's an error if the passwords aren't encrypted
+#
+# config values can be encrypted with dsetool encryptconfigvalue
+config_encryption_active: <%= node['cassandra']['dse']['config_encryption_active'] %>
+
+# the name of the system key used to encrypt / decrypt passwords stored
+# in configuration files.
+#
+# If config_encryption_active is true, it's an error if a valid key with
+# this name isn't in the system key directory
+#
+# keyfiles, and KMIP managed keys can be created with dsetool createsystemkey
+config_encryption_key_name: <%= node['cassandra']['dse']['config_encryption_key_name'] %>
+
+# Spark
+# The fraction of available system resources to be used by Spark Worker
+#
+# This the only initial value, once it is reconfigured, the new value is stored
+# and retrieved on next run.
+initial_spark_worker_resources: 0.7
+
+# The length of a shared secret used to authenticate Spark components and encrypt the connections between them.
+# Note that this is not the strength of the cipher used for encrypting connections.
+spark_shared_secret_bit_length: 256
+
+# Enables Spark security based on shared secret infrastructure. This means enabling mutual authentication of
+# the Spark components as well as encryption of communication channels except Web UI.
+spark_security_enabled: false
+
+hadoop_options:
+  # The maximum number of slots that can be allocated by TaskTracker for running user tasks. By default, this value is
+  # calculated automatically. When specified manually it denotes the maximum total number of mappers and reducers which
+  # can be simultaneously run by the task tracker. Note that the individual number of mappers or reducers will never be
+  # greater than the number of physical cores - 1.
+  # task_tracker_cores: 2
+  # The maximum amount of memory that can be allocated by TaskTracker for running user tasks. By default, this value is
+  # calculated automatically. Note that this is the total memory which will be split among particular slots. It also
+  # includes Java overhead which is 128m per single slot. However, the maximum heap size of a single mapper or reducer
+  # will be no less than 256m which is the hardcoded minimum.
+  # You can use typical suffixes for memory sizes: k - kilo, m - mega, g - giga, and so on
+  # task_tracker_memory: 4g
+
+# How often Spark plugin should check for Spark Master / Worker readiness to start. The value is
+# a time (in ms) between subsequent retries.
+# spark_daemon_readiness_assertion_interval: 1000
+
+# Spark encryption can be enabled for Spark client to Spark cluster and Spark internode communication.
+# It applies to 2 out of 4 communication protocols in Spark: control messages via Akka and file
+# sharing via HTTP(S). It does not apply to RDD data exchange or to web UI. This means that
+# the encryption is used to send all configuration settings and all files which are required
+# by Spark application. They include passwords and tokens.
+#
+# Spark encryption requires truststores to be defined.
+#
+# If truststore or keystore is provided as a relative file path, the base directory for them is
+# Spark config directory denoted by SPARK_CONF_DIR environment variable (by default is points to
+# resources/spark/conf).
+spark_encryption_options:
+    enabled: false
+    keystore: .keystore
+    keystore_password: cassandra
+    key_password: cassandra
+    truststore: .truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
+
+# DSE File System options
+dsefs_options:
+  enabled: false
+
+  # Keyspace for storing the DSE FS metadata
+  keyspace_name: dsefs
+
+  # The local directory for storing node-local metadata e.g. the node identifier
+  # The amount of data stored there is tiny, so no special throughput, latency nor capacity are required.
+  # The work directory must not be shared by DSE FS nodes.
+  work_dir: /var/lib/dsefs
+
+  # Port for DSE FS clients, the service on this port will be bound to RPC address.
+  public_port: 5598
+
+  # Port for internode communication, must be not visible from outside of the cluster. It will be bound to listen address.
+  private_port: 5599
+
+  # Set of directories for storing the file data. 'dir' attribute is mandatory.
+  #     - dir: /var/lib/dsefs/data
+  #       storage_weight: 1.0
+  #       min_free_space: 5368709120
+  #     - dir: /other/device
+  #       storage_weight: 1.5
+  # It is recommended to put them on different physical devices than devices used for Cassandra.
+  # Using multiple directories on JBOD improves performance and capacity.
+  data_directories:
+    - dir: /var/lib/dsefs/data
+      # How much data should be placed in this directory relative to other directories in the cluster
+      storage_weight: 1.0
+      # Reserved space (in bytes) that is not going to be used for storing blocks
+      min_free_space: 5368709120
+
+  # # More advanced settings below:
+  # # How long DseFs Server is going to wait for services to bootstrap
+  # service_startup_timeout_ms: 30000
+  # # How long DseFs Server is going to wait for services to close
+  # service_close_timeout_ms: 600000
+  # # How long DseFs Server is going to wait close all pending connections during shutdown
+  # server_close_timeout_ms: # Integer.MAX_VALUE
+  # gossip_options:
+  #   # The delay between gossip rounds
+  #   round_delay_ms: 5000
+  #   # How long to wait after registering the Location and reading back all other Locations from
+  #   # Cassandra
+  #   startup_delay_ms: 5000
+  #   # How long to wait after announcing shutdown before shutting down the node
+  #   shutdown_delay_ms: 30000
+  # rest_options:
+  #   # How long RestClient is going to wait for a response corresponding to a given request
+  #   request_timeout_ms: 330000
+  #   # How long RestClient is going to wait for establishing a new connection
+  #   connection_open_timeout_ms: 55000
+  #   # How long RestClient is going to wait until all pending transfers are complete before closing
+  #   client_close_timeout_ms: 60000
+  #   # How long to wait for the server rest call to complete
+  #   server_request_timeout_ms: 300000
+  # transaction_options:
+  #   # How long to allow a transaction to run before considering it for timing out and rollback
+  #   transaction_timeout_ms: 3000
+  #   # How long to wait before retrying a transaction aborted due to a conflict
+  #   conflict_retry_delay_ms: 200
+  #   # How long to wait before retrying a failed transaction payload execution
+  #   execution_retry_delay_ms: 1000
+  #   # How many times to retry executing the payload before signaling the error to the application
+  #   execution_retry_count: 3
+
+# Audit logging options
+audit_logging_options:
+  enabled: <%= node['cassandra']['dse']['audit_logging_options']['enabled'] %>
+  # The logger used for logging audit information
+  # Available loggers are:
+  #   CassandraAuditWriter: logs audit info to a cassandra table. This logger can be run either synchronously, or
+  #                         asynchronously. Audit logs are stored in the dse_audit.audit_log table.
+  #                         When run synchronously, a query will not execute until it has been written
+  #                         to the audit log table successfully. If there is a failure between when an audit event is
+  #                         written, and it's query is executed, the audit logs may contain queries that were never
+  #                         executed.
+  #   SLF4JAuditWriter:     logs audit info to an slf4j logger. The logger name is `SLF4JAuditWriter`, and can be configured
+  #                         in the logback.xml file.
+  logger: <%= node['cassandra']['dse']['audit_logging_options']['logger'] %>
+
+  # Comma separated list of audit event categories to be included or excluded from the audit log.
+  # Defaults to including all categories and keyspaces.
+  # Categories are: QUERY, DML, DDL, DCL, AUTH, ADMIN, ERROR
+  # Specify either included or excluded categories. Specifying both is an error
+  <%= !node['cassandra']['dse']['audit_logging_options']['included_categories'].empty? ? "included_categories: #{node['cassandra']['dse']['audit_logging_options']['included_categories']}" : "# included_categories:" %>
+  <%= !node['cassandra']['dse']['audit_logging_options']['excluded_categories'].empty? ? "excluded_categories: #{node['cassandra']['dse']['audit_logging_options']['excluded_categories']}" : "# excluded_categories:" %>
+
+  # Comma separated list of keyspaces to be included or excluded from the audit log.
+  # Specify either included or excluded keyspaces. Specifying both is an error
+  <%= !node['cassandra']['dse']['audit_logging_options']['included_keyspaces'].empty? ? "included_keyspaces: #{node['cassandra']['dse']['audit_logging_options']['included_keyspaces']}" : "# included_keyspaces:" %>
+  <%= !node['cassandra']['dse']['audit_logging_options']['excluded_keyspaces'].empty? ? "excluded_keyspaces: #{node['cassandra']['dse']['audit_logging_options']['excluded_keyspaces']}" : "# excluded_keyspaces:" %>
+
+  # The amount of time, in hours, audit events are retained by supporting loggers
+  # Currently, only the CassandraAuditWriter supports retention time
+  # values of 0 or less retain events forever
+  retention_time: <%= node['cassandra']['dse']['audit_logging_options']['retention_time'] %>
+
+  cassandra_audit_writer_options:
+    # sets the mode the writer runs in.
+    #
+    # When run synchronously, a query is not executed until the audit event is successfully written.
+    #
+    # When run asynchronously, audit events are queued for writing to the audit table, but are
+    # not necessarily logged before the query executes. A pool of writer threads consumes the
+    # audit events from the queue, and writes them to the audit table in batch queries. While
+    # this substantially improves performance under load, if there is a failure between when
+    # a query is executed, and it's audit event is written to the table, the audit table may
+    # be missing entries for queries that were executed.
+    # valid options are 'sync' and 'async'
+    mode: <%= node['cassandra']['dse']['audit_logging_options']['cassandra_audit_writer_options']['mode'] %>
+
+    # The maximum number of events the writer will dequeue before writing them out to the table. If you're seeing
+    # warnings in your logs about batches being too large, decrease this value. Increasing batch_size_warn_threshold_in_kb
+    # in cassandra.yaml is also an option, but make sure you understand the implications before doing so.
+    #
+    # Only used in async mode. Must be >0
+    batch_size: <%= node['cassandra']['dse']['audit_logging_options']['cassandra_audit_writer_options']['batch_size'] %>
+
+    # The maximum amount of time in milliseconds an event will be dequeued by a writer before being written out. This
+    # prevents events from waiting too long before being written to the table when there's not a lot of queries happening.
+    #
+    # Only used in async mode. Must be >0
+    flush_time: <%= node['cassandra']['dse']['audit_logging_options']['cassandra_audit_writer_options']['flush_time'] %>
+
+    # The number of worker threads asynchronously logging events to the CassandraAuditWriter.
+    #
+    # Only used in async mode. Must be >0
+    num_writers: <%= node['cassandra']['dse']['audit_logging_options']['cassandra_audit_writer_options']['num_writers'] %>
+
+    # The size of the queue feeding the asynchronous audit log writer threads. When there are more events being
+    # produced than the writers can write out, the queue will fill up, and newer queries will block until there
+    # is space on the queue.
+    # If a value of 0 is used, the queue size will be unbounded, which can lead to resource exhaustion under
+    # heavy query load.
+    queue_size: <%= node['cassandra']['dse']['audit_logging_options']['cassandra_audit_writer_options']['queue_size'] %>
+
+    # the consistency level used to write audit events
+    write_consistency: <%= node['cassandra']['dse']['audit_logging_options']['cassandra_audit_writer_options']['write_consistency'] %>
+
+    # Where dropped events are logged
+    # dropped_event_log: /var/log/cassandra/dropped_audit_events.log
+
+    # Partition days into hours by default
+    # day_partition_millis: 3600000
+
+# If enabled, system tables that may contain sensitive information (system.batchlog,
+# system.paxos), hints files and Cassandra commit logs are encrypted with the
+# encryption settings below.
+#
+# If Solr index encryption is enabled, Solr index files are also encrypted with the settings below.
+# If backing C* table encryption is enabled, DSE search commit log is encrypted with settings below.
+#
+# When enabling system table encryption on a node with existing data, run
+# `nodetool upgradesstables -a` on the listed tables to encrypt existing data
+#
+# When tracing is enabled, sensitive info will be written into the tables in the
+# system_traces keyspace. Those tables should be configured to encrypt their data
+# on disk by using an encrypting compressor.
+system_info_encryption:
+  enabled: <%= node['cassandra']['dse']['system_info_encryption']['enabled'] %>
+  cipher_algorithm: <%= node['cassandra']['dse']['system_info_encryption']['cipher_algorithm'] %>
+  secret_key_strength: <%= node['cassandra']['dse']['system_info_encryption']['secret_key_strength'] %>
+  chunk_length_kb: <%= node['cassandra']['dse']['system_info_encryption']['chunk_length_kb'] %>
+  # the name of the keys file that will be created to encrypt system tables.
+  # This file will be created at <system_key_directory>/system/<key_name>
+  key_name: <%= node['cassandra']['dse']['system_info_encryption']['key_name'] %>
+
+  # selects an alternate key provider for local encryption. Useful for
+  # using a kmip host as a key provider
+  # key_provider: KmipKeyProviderFactory
+
+  # if  KmipKeyProviderFactory is used for system_info_encryption, this specified
+  # the kmip host to be used
+  # kmip_host: kmip_host_name
+
+# Retries setting when hive inserts data to C* table. insert_max_retries is max number of retries
+# insert_retry_sleep_period is the period of time in milliseconds between retries
+hive_options:
+  insert_max_retries: 6
+  insert_retry_sleep_period: 50
+
+# Connection settings for key servers supporting the kmip protocol
+# this allows DSE's encryption features to use keys that are not stored
+# on the same machine running DSE.
+#
+# Hosts are configured as <kmip_host_name> : <connection_settings>, which maps a user definable
+# name to a set of hosts, truststores, etc used with a particular key server. This name is then
+# used when referring to kmip hosts. DSE supports multiple kmip hosts.
+# kmip_hosts:
+  # the unique name of this kmip host/cluster which is specified in the table schema
+  # kmip_host_name:
+    # comma separated list of kmip hosts host[:port]
+    # The current implementation of KMIP connection management only supports failover, so all requests will
+    # go through a single KMIP server. There is no load balancing. This is because there aren't any KMIP servers
+    # available (that we've found) that support read replication, or other strategies for availability.
+    #
+    # Hosts are tried in the order they appear here. So add them in the same sequence they'll fail over in
+    # hosts: kmip1.yourdomain.com, kmip2.yourdomain.com
+
+    # keystore/truststore info
+    # keystore_path: /path/to/keystore.jks
+    # keystore_type: jks
+    # keystore_password: password
+    # truststore_path: /path/to/truststore.jks
+    # truststore_type: jks
+    # truststore_password: password
+
+    # Keys read from the KMIP hosts are cached locally for the period of time specified below.
+    # The longer keys are cached, the fewer requests are made to the key server, but the longer
+    # it takes for changes (ie: revokation) to propagate to the DSE node
+    # key_cache_millis: 300000
+
+    # socket timeout in milliseconds
+    # timeout: 1000
+
+# When 'driver' DSE Search will use Solr cursor paging when pagination is enabled by the CQL driver.
+#
+# When 'off' DSE Search will ignore the driver's pagination settings and use normal Solr paging unless:
+#   - The current workload is an analytics workload (ex. SearchAnalytics).
+#   - The query parameter 'paging' is set to 'driver'.
+#
+# Default is 'off'
+#
+# cql_solr_query_paging: off
+
+# Local settings for tiered storage
+#
+# Tiered supports multiple disk configurations, which are configured as <config_name> : <config_settings>, and specified in DDL
+# The tiers themselves are unnamed, and are just collections of paths, which need to be defined in the order they're to be used.
+# Typically, you'd put your fastest storage in the top tier, and go down from there.
+#
+# Storage configurations don't need to be homogenous across the cluster, and internally, each node will only make use of the
+# the number of tiers it actually has configured, or the number of tiers configured to be used in the DDL, whichever is less.
+#
+# Although the behavior of the tiered strategy for a given table is configured in the DDL, these settings can
+# be overridden locally, per node, by specifying 'local_options' : {<k>:<v>, ...} in a config. This can be useful for testing
+# options before deploying cluster wide, or for storage configurations which don't map cleanly to the DDL configuration.
+#
+#tiered_storage_options:
+#  strategy1:
+#    tiers:
+#      - paths:
+#          - /mnt1
+#          - /mnt2
+#
+#      - paths:
+#          - /mnt3
+#          - /mnt4
+#
+#      - paths:
+#          - /mnt5
+#          - /mnt6
+
+# DSE Advanced Replication configuration settings
+# DSE Advanced replication supports one-way distributed data replication from remote
+# clusters to central data hubs.
+# When conf_driver_password_encryption_enabled: true, the driver password stored in the advrep config is expected to be encrypted
+#                                                     with the dse configuration encryption using the systemkey. The same systemkey
+#                                                     that was used to create the driver password, must be copied to every node in
+#                                                     the cluster.
+#advanced_replication_options:
+#  enabled: false
+#  conf_driver_password_encryption_enabled: false
+
+# These internode_messaging_options configure network services for internal communication
+# for all nodes. These settings must be identical on all nodes in the cluster.
+internode_messaging_options:
+  # TCP listen port (mandatory)
+  port: 8609
+
+  # Max message frame length (default 256MB)
+  # frame_length_in_mb: 256
+
+  # Number of server acceptor threads (default is number of available processors)
+  # server_acceptor_threads: 8
+
+  # Number of server worker threads (default is number of available processors * 8)
+  # server_worker_threads: 16
+
+  # Max number of client connections
+  # client_max_connections: 100
+
+  # Number of client worker threads (default is number of available processors * 8)
+  # client_worker_threads: 16
+
+  # Timeout for comm handshake process (default is 10 seconds)
+  # handshake_timeout_seconds: 10
+
+# System namespace for DSE Graph contains all system-level configuration options
+# and those shared between graph instances.
+graph:
+  # Maximum time to wait for a analytic traversal to evaluate. Value: a duration
+  # composed of a number and a unit, such as "10 h", "45 sec", "60 ms", or an
+  # ISO-8601 duration string such as "PT1M10S".
+  analytic_evaluation_timeout: PT168H
+
+  # The maximum number of threads to use for queries to Cassandra. By default this is 10 * gremlinPool.
+  #max_query_threads:
+
+  # The maximum number of CQL queries that can be queued as a result of Gremlin
+  # requests.  If that number is exceeded, new queries are rejected.
+  max_query_queue: 10000
+
+  # Maximum time to wait for a real-time traversal to evaluate. Value: a duration
+  # composed of a number and a unit, such as "10 h", "45 sec", "60 ms", or an
+  # ISO-8601 duration string such as "PT1M10S".
+  realtime_evaluation_timeout: 30 sec
+
+  # Maximum time to wait for cassandra to agree on schema versions before timing
+  # out. Value: a duration composed of a number and a unit, such as "10 h", "45
+  # sec", "60 ms", or an ISO-8601 duration string such as "PT1M10S".
+  schema_agreement_timeout: 10 sec
+
+  # Maximum time to wait for a system-based request to execute. Value: a duration
+  # composed of a number and a unit, such as "10 h", "45 sec", "60 ms", or an
+  # ISO-8601 duration string such as "PT1M10S".
+  system_evaluation_timeout: PT3M
+
+  # The number of samples to keep when aggregating. Value: integer.
+  window_size: 100000
+
+  # Configuration options for id assignment and partitioning strategies.
+  ids:
+    # At what percentage of consumed ids should a new id block allocation be
+    # triggered. Value must be between 0 and 1. Value: double.
+    block_renew: 0.8
+
+    # The maximum number of times a transaction will allocate an ID from a single
+    # community before switching to a different community. Value: long.
+    community_reuse: 28
+
+    # An integer between 1 and 2^24 (both inclusive) that affects maximum ID capacity
+    # and the maximum storage space used by ID allocations.  Lower values reduce the
+    # number of available IDs but make ID allocation more efficient in both storage
+    # space and lightweight transaction overhead.  Higher values consume more storage
+    # space and LWT overhead, but make more of the total ID space available. Value:
+    # integer.
+    id_hash_modulus: 20
+
+    # Member IDs are allocated from communities in blocks of this size. Value:
+    # integer.
+    member_block_size: 512
+
+  # Contains all registered state listeners identified by their name.
+  listener:
+#     # On the following line, "listener_name" is a placeholder string.  This can be
+#     # changed to an arbitrary string composed of lowercase letters, numbers, and
+#     # underscores, where the string begins with a lowercase letter.
+#     listener_name:
+#       # The names of state types that are ignored. All state types but those given are
+#       # listened to. Value: YAML-formatted list of strings.
+#       black_types:  # This list is empty by default
+#
+#       # The interval in which the state values are logged. Value: a duration composed of
+#       # a number and a unit, such as "10 h", "45 sec", "60 ms", or an ISO-8601 duration
+#       # string such as "PT1M10S".
+#       interval: PT1H
+#
+#       # The type of the state listener. Must be one of: [slf4j]. Value: string.
+#       type: slf4j
+#
+#       # The names of state types that should be listened. Only those state types are
+#       # listened to and all others ignored. Value: YAML-formatted list of strings.
+#       white_types:  # This list is empty by default
+#
+  # Configuration options graph's internal query forwarding and lightweight
+  # messaging system.
+  msg:
+    # Graph messages must be acknowledged within this interval, or else the message
+    # will be assumed dropped/failed.  Graph will retry the message or fail the
+    # responsible request if the retry limit has been exceeded. Value: a duration
+    # composed of a number and a unit, such as "10 h", "45 sec", "60 ms", or an
+    # ISO-8601 duration string such as "PT1M10S".
+    graph_msg_timeout: 5 sec
+
+  # Contains all registered event observers identified by their name.
+  observer:
+#     # On the following line, "observer_name" is a placeholder string.  This can be
+#     # changed to an arbitrary string composed of lowercase letters, numbers, and
+#     # underscores, where the string begins with a lowercase letter.
+#     observer_name:
+#       # The names of event types that are ignored. All event types but those given are
+#       # observed. Value: YAML-formatted list of strings.
+#       black_types:  # This list is empty by default
+#
+#       # The names of the graphs for which events are observed. Value:
+#       # YAML-formatted list of strings.
+#       observed_graphs:  # This list is empty by default
+#
+#       # Threshold at which slow events get reported. Value: a duration composed of a
+#       # number and a unit, such as "10 h", "45 sec", "60 ms", or an ISO-8601 duration
+#       # string such as "PT1M10S".
+#       slow_threshold: PT5M
+#
+#       # The type of the event observer. Must be one of: [slf4j,
+#       # slow_request]. Value: string.
+#       type: slf4j
+#
+#       # The names of event types that should be observed. Only those event types are
+#       # observed and all others ignored. Value: YAML-formatted list of strings.
+#       white_types:  # This list is empty by default
+#
+  # Shared data.
+  shared_data:
+    # The interval between refreshes. Value: a duration composed of a number and a
+    # unit, such as "10 h", "45 sec", "60 ms", or an ISO-8601 duration string such as
+    # "PT1M10S".
+    refresh_interval: PT1M
+
+  # This is the default and generally minimal configuration for Gremlin Server. The full list of
+  # configuration options can be found in the TinkerPop documentation:
+  #
+  # http://tinkerpop.apache.org/docs/3.1.0-incubating/#_configuring_2
+  #
+  # Note that for DSE Graph, the top-level configurations in Gremlin Server are embedded in a key called
+  # gremlin_server. It is further important to understand that while most configuration options for
+  # Gremlin Server come from these settings, there are some that are ignored and overridden:
+  #
+  # - authentication: This setting is ignored as Gremlin Server delegates all security to DSE.
+  # - channelizer: The Channelizer implementation for Gremlin Server is always set to
+  #   DseWebSocketChannelizer which includes hooks into DSE audit and authentication features.
+  # - graphs: The list of graphs are completely ignored. Graph instances are created when they are
+  #   requested.
+  # - host: The host is ignored, it is always equal to rpc_address from cassandra.yaml
+  gremlin_server:
+    maxContentLength: 65536000
+    maxChunkSize: 4096000
+    port: <%= node[:graph][:port] %> #8182
+    serializers:
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistry], classResolverSupplier: com.datastax.bdp.graph.impl.tinkerpop.io.DseClassResolverProvider }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistry], classResolverSupplier: com.datastax.bdp.graph.impl.tinkerpop.io.DseClassResolverProvider }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistry] }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistry] }}
+    scriptEngines:
+      gremlin-groovy:
+        config:
+          compilerCustomizerProviders:
+            "org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.ThreadInterruptCustomizerProvider": []
+            "org.apache.tinkerpop.gremlin.groovy.jsr223.customizer.InterpreterModeCustomizerProvider": []
+
+  # This option controls the way schemas are handled. Use one of:
+  #   Development - No schema is required
+  #   Production - Schemas are required
+  schema_mode: Production


### PR DESCRIPTION
Basically just adding the templates and adding configuration parameters as they existed in 4.8.1.

Some things you might want to check with regard to if they're done to your liking:

 * graph parameter are given in `attributes/graph.rb`
 * had to add template `templates/default/cassandra-jvm.options.erb`, which was introduced in 5.0.0
 * added configuration options `listen_interface` and `rpc_interface`, which will be used instead of `listen_address` and `rpc_address` respectively. 

Let me know if I can help with making this more consumable for you in any way.