### PR TITLE
Add two more tunables for cassandra 3.x

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -68,6 +68,10 @@ default['cassandra']['thrift_max_message_length_in_mb'] = nil
 default['cassandra']['concurrent_compactors']   = nil
 default['cassandra']['permissions_validity_in_ms']  = 2000
 
+# cassandra > 3.0 / dse > 5.0
+default['cassandra']['allocate_tokens_for_keyspace'] = nil
+default['cassandra']['disk_optimization_strategy'] = nil
+
 # Role based search to assign seed nodes.
 default['cassandra']['role_based_seeds'] = false
 default['cassandra']['seed_role']        = 'role:dse-seed'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'daniel.c.parker@target.com'
 license 'Apache 2.0'
 description 'Installs/Configures Datastax Enterprise.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.0.34'
+version '3.0.35'
 
 %w(redhat centos).each do |name|
   supports name, '>= 6.4'

--- a/templates/default/cassandra_yaml/cassandra_5.0.0-1.yaml.erb
+++ b/templates/default/cassandra_yaml/cassandra_5.0.0-1.yaml.erb
@@ -33,7 +33,11 @@ num_tokens: <%=node[:cassandra][:num_tokens]%> # 128
 # vnodes.
 #
 # Only supported with the Murmur3Partitioner.
+<% if node[:cassandra][:allocate_tokens_for_keyspace] -%>
+allocate_tokens_for_keyspace: <%= node[:cassandra][:allocate_tokens_for_keyspace] %>
+<% else -%>
 # allocate_tokens_for_keyspace: KEYSPACE
+<% end -%>
 
 # initial_token allows you to specify tokens manually.  While you can use # it with
 # vnodes (num_tokens > 1, above) -- in which case you should provide a
@@ -404,7 +408,11 @@ concurrent_materialized_view_writes: 32
 # Possible values are:
 # ssd (for solid state disks, the default)
 # spinning (for spinning disks)
+<% if node[:cassandra][:disk_optimization_strategy] -%>
+disk_optimization_strategy: <%= node[:cassandra][:disk_optimization_strategy] %>
+<% else -%>
 # disk_optimization_strategy: ssd
+<% end -%>
 
 # Total permitted memory to use for memtables. Cassandra will stop
 # accepting writes when the limit is exceeded until a flush completes,


### PR DESCRIPTION
This PR adds two attributes, `allocate_tokens_for_keyspace` and `disk_optimization_strategy`

See http://www.datastax.com/dev/blog/token-allocation-algorithm for more info on the first setting.